### PR TITLE
Make token in MatchMakerMatched optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix parsing of MatchmakerMatched messages when no token is specified.
+
 ## [1.0.0] - 2020-01-28
 ### Added
 - Initial public release.

--- a/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
@@ -367,7 +367,7 @@ class MatchmakerMatched extends NakamaAsyncResult:
 	const _SCHEMA = {
 		"match_id": {"name": "match_id", "type": TYPE_STRING, "required": false},
 		"ticket": {"name": "ticket", "type": TYPE_STRING, "required": true},
-		"token": {"name": "token", "type": TYPE_STRING, "required": true},
+		"token": {"name": "token", "type": TYPE_STRING, "required": false},
 		"users": {"name": "users", "type": TYPE_ARRAY, "required": false, "content": "MatchmakerUser"},
 		"self": {"name": "self_user", "type": "MatchmakerUser", "required": true}
 	}


### PR DESCRIPTION
Custom server logic allows it to return a `matchmaker_matched` without a token and only the `match_id`.
This commit relaxes the requirements of `MatchMakerMatched` schema so it does not fail to parse those cases.

Fixes #14