### PR TITLE
Decode base64 data in MatchData, disable use_threads in HTML5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+- Decode base64 data in `MatchData`. (breaks compat)
+
 ### Fixed
 
 - Fix encoding of `op_code` in `MatchDataSend` and marshalling of `NakamaSocket.send_match_state_[raw_]async`.
 - Fix parsing of `MatchmakerMatched` messages when no token is specified.
+- Disable `HTTPRequest.use_threads` in HTML5 exports.
 
 ## [1.0.0] - 2020-01-28
 ### Added

--- a/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
@@ -315,7 +315,10 @@ class MatchData extends NakamaAsyncResult:
 		return "MatchData<match_id=%s, op_code=%s, data=%s>" % [match_id, op_code, data]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> MatchData:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "MatchData", p_dict), MatchData) as MatchData
+		var out := _safe_ret(NakamaSerializer.deserialize(p_ns, "MatchData", p_dict), MatchData) as MatchData
+		if out.data: # Decode base64 received data
+			out.data = Marshalls.base64_to_utf8(out.data)
+		return out
 
 	static func get_result_key() -> String:
 		return "match_data"

--- a/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
@@ -25,7 +25,8 @@ var id : int = 0
 ### <returns>A task which resolves to the contents of the response.</returns>
 func send_async(p_method : String, p_uri : String, p_headers : Dictionary, p_body : PoolByteArray, p_timeout : int = 3):
 	var req = HTTPRequest.new()
-	req.use_threads = true
+	if OS.get_name() != 'HTML5':
+		req.use_threads = true # Threads not available nor needed on the web.
 
 	# Parse method
 	var method = HTTPClient.METHOD_GET


### PR DESCRIPTION
Threads are not (yet) supported in HTML5 exports, and are in any case not needed since HTTPRequests are always async in browsers.

`MatchData` decode is a bit hacky compared to the rest of the code.
A cleaner solution would probably be to add a condition for that in the serializer, but for just one case it's not worth it.
Should reconsider if more base64 messages needs to be handled.

Fixes #19 
Fixes #18 