### PR TITLE
Allow updating account without updating username.

### DIFF
--- a/addons/com.heroiclabs.nakama/client/NakamaClient.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaClient.gd
@@ -803,7 +803,7 @@ func unlink_steam_async(p_session : NakamaSession, p_token : String) -> NakamaAs
 ### <param name="p_location">A new location for the user.</param>
 ### <param name="p_timezone">New timezone information for the user.</param>
 ### <returns>A task which represents the asynchronous operation.</returns>
-func update_account_async(p_session : NakamaSession, p_username : String, p_display_name = null,
+func update_account_async(p_session : NakamaSession, p_username = null, p_display_name = null,
 		p_avatar_url = null, p_lang_tag = null, p_location = null, p_timezone = null) -> NakamaAsyncResult:
 	return _api_client.update_account_async(p_session.token,
 		NakamaAPI.ApiUpdateAccountRequest.create(NakamaAPI, {


### PR DESCRIPTION
So that you can pass `null` to the username parameter of `update_account_async`:
`client.update_account_async(session, null, ...)`