### PR TITLE
Update main.go, remove XML tags in the GDScript docstrings

### DIFF
--- a/addons/com.heroiclabs.nakama/Nakama.gd
+++ b/addons/com.heroiclabs.nakama/Nakama.gd
@@ -1,29 +1,19 @@
 tool
 extends Node
 
-### <summary>
-### The default host address of the server.
-### </summary>
+# The default host address of the server.
 const DEFAULT_HOST : String = "127.0.0.1"
 
-### <summary>
-### The default port number of the server.
-### </summary>
+# The default port number of the server.
 const DEFAULT_PORT : int = 7350
 
-### <summary>
-### The default timeout for the connections.
-### </summary>
+# The default timeout for the connections.
 const DEFAULT_TIMEOUT = 3
 
-### <summary>
-### The default protocol scheme for the client connection.
-### </summary>
+# The default protocol scheme for the client connection.
 const DEFAULT_CLIENT_SCHEME : String = "http"
 
-### <summary>
-### The default protocol scheme for the socket connection.
-### </summary>
+# The default protocol scheme for the socket connection.
 const DEFAULT_SOCKET_SCHEME : String = "ws"
 
 const DEFAULT_LOG_LEVEL = NakamaLogger.LOG_LEVEL.DEBUG

--- a/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
@@ -3108,8 +3108,8 @@ class ApiClient extends Reference:
 
 	# Add Facebook Instant Game to the social profiles on the current user's account.
 	func link_facebook_instant_game_async(
-		p_bearer_token : String
-		, p_body : ApiAccountFacebookInstantGame
+		p_bearer_token : String,
+		p_body : ApiAccountFacebookInstantGame
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/link/facebookinstantgame"
 		var query_params = ""

--- a/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
@@ -3,9 +3,7 @@
 extends Reference
 class_name NakamaAPI
 
-### <summary>
-### A single user-role pair.
-### </summary>
+# A single user-role pair.
 class GroupUserListGroupUser extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -13,17 +11,13 @@ class GroupUserListGroupUser extends NakamaAsyncResult:
 		"user": {"name": "_user", "type": "ApiUser", "required": false},
 	}
 
-	### <summary>
-	### Their relationship to the group.
-	### </summary>
+	# Their relationship to the group.
 	var state : int setget , _get_state
 	var _state = null
 	func _get_state() -> int:
 		return 0 if not _state is int else int(_state)
 
-	### <summary>
-	### User.
-	### </summary>
+	# User.
 	var user : ApiUser setget , _get_user
 	var _user = null
 	func _get_user() -> ApiUser:
@@ -46,9 +40,7 @@ class GroupUserListGroupUser extends NakamaAsyncResult:
 		output += "user: %s, " % _user
 		return output
 
-### <summary>
-### A single group-role pair.
-### </summary>
+# A single group-role pair.
 class UserGroupListUserGroup extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -56,17 +48,13 @@ class UserGroupListUserGroup extends NakamaAsyncResult:
 		"state": {"name": "_state", "type": TYPE_INT, "required": false},
 	}
 
-	### <summary>
-	### Group.
-	### </summary>
+	# Group.
 	var group : ApiGroup setget , _get_group
 	var _group = null
 	func _get_group() -> ApiGroup:
 		return _group as ApiGroup
 
-	### <summary>
-	### The user's relationship to the group.
-	### </summary>
+	# The user's relationship to the group.
 	var state : int setget , _get_state
 	var _state = null
 	func _get_state() -> int:
@@ -89,9 +77,7 @@ class UserGroupListUserGroup extends NakamaAsyncResult:
 		output += "state: %s, " % _state
 		return output
 
-### <summary>
-### Record values to write.
-### </summary>
+# Record values to write.
 class WriteLeaderboardRecordRequestLeaderboardRecordWrite extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -100,25 +86,19 @@ class WriteLeaderboardRecordRequestLeaderboardRecordWrite extends NakamaAsyncRes
 		"subscore": {"name": "_subscore", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### Optional record metadata.
-	### </summary>
+	# Optional record metadata.
 	var metadata : String setget , _get_metadata
 	var _metadata = null
 	func _get_metadata() -> String:
 		return "" if not _metadata is String else String(_metadata)
 
-	### <summary>
-	### The score value to submit.
-	### </summary>
+	# The score value to submit.
 	var score : String setget , _get_score
 	var _score = null
 	func _get_score() -> String:
 		return "" if not _score is String else String(_score)
 
-	### <summary>
-	### An optional secondary value.
-	### </summary>
+	# An optional secondary value.
 	var subscore : String setget , _get_subscore
 	var _subscore = null
 	func _get_subscore() -> String:
@@ -142,9 +122,7 @@ class WriteLeaderboardRecordRequestLeaderboardRecordWrite extends NakamaAsyncRes
 		output += "subscore: %s, " % _subscore
 		return output
 
-### <summary>
-### Record values to write.
-### </summary>
+# Record values to write.
 class WriteTournamentRecordRequestTournamentRecordWrite extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -153,25 +131,19 @@ class WriteTournamentRecordRequestTournamentRecordWrite extends NakamaAsyncResul
 		"subscore": {"name": "_subscore", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### A JSON object of additional properties (optional).
-	### </summary>
+	# A JSON object of additional properties (optional).
 	var metadata : String setget , _get_metadata
 	var _metadata = null
 	func _get_metadata() -> String:
 		return "" if not _metadata is String else String(_metadata)
 
-	### <summary>
-	### The score value to submit.
-	### </summary>
+	# The score value to submit.
 	var score : String setget , _get_score
 	var _score = null
 	func _get_score() -> String:
 		return "" if not _score is String else String(_score)
 
-	### <summary>
-	### An optional secondary value.
-	### </summary>
+	# An optional secondary value.
 	var subscore : String setget , _get_subscore
 	var _subscore = null
 	func _get_subscore() -> String:
@@ -195,9 +167,7 @@ class WriteTournamentRecordRequestTournamentRecordWrite extends NakamaAsyncResul
 		output += "subscore: %s, " % _subscore
 		return output
 
-### <summary>
-### A user with additional account details. Always the current user.
-### </summary>
+# A user with additional account details. Always the current user.
 class ApiAccount extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -209,49 +179,37 @@ class ApiAccount extends NakamaAsyncResult:
 		"wallet": {"name": "_wallet", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### The custom id in the user's account.
-	### </summary>
+	# The custom id in the user's account.
 	var custom_id : String setget , _get_custom_id
 	var _custom_id = null
 	func _get_custom_id() -> String:
 		return "" if not _custom_id is String else String(_custom_id)
 
-	### <summary>
-	### The devices which belong to the user's account.
-	### </summary>
+	# The devices which belong to the user's account.
 	var devices : Array setget , _get_devices
 	var _devices = null
 	func _get_devices() -> Array:
 		return Array() if not _devices is Array else Array(_devices)
 
-	### <summary>
-	### The email address of the user.
-	### </summary>
+	# The email address of the user.
 	var email : String setget , _get_email
 	var _email = null
 	func _get_email() -> String:
 		return "" if not _email is String else String(_email)
 
-	### <summary>
-	### The user object.
-	### </summary>
+	# The user object.
 	var user : ApiUser setget , _get_user
 	var _user = null
 	func _get_user() -> ApiUser:
 		return _user as ApiUser
 
-	### <summary>
-	### The UNIX time when the user's email was verified.
-	### </summary>
+	# The UNIX time when the user's email was verified.
 	var verify_time : String setget , _get_verify_time
 	var _verify_time = null
 	func _get_verify_time() -> String:
 		return "" if not _verify_time is String else String(_verify_time)
 
-	### <summary>
-	### The user's wallet data.
-	### </summary>
+	# The user's wallet data.
 	var wallet : String setget , _get_wallet
 	var _wallet = null
 	func _get_wallet() -> String:
@@ -278,9 +236,7 @@ class ApiAccount extends NakamaAsyncResult:
 		output += "wallet: %s, " % _wallet
 		return output
 
-### <summary>
-### Send a custom ID to the server. Used with authenticate/link/unlink.
-### </summary>
+# Send a custom ID to the server. Used with authenticate/link/unlink.
 class ApiAccountCustom extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -288,17 +244,13 @@ class ApiAccountCustom extends NakamaAsyncResult:
 		"vars": {"name": "_vars", "type": TYPE_DICTIONARY, "required": false},
 	}
 
-	### <summary>
-	### A custom identifier.
-	### </summary>
+	# A custom identifier.
 	var id : String setget , _get_id
 	var _id = null
 	func _get_id() -> String:
 		return "" if not _id is String else String(_id)
 
-	### <summary>
-	### Extra information that will be bundled in the session token.
-	### </summary>
+	# Extra information that will be bundled in the session token.
 	var vars : Dictionary setget , _get_vars
 	var _vars = null
 	func _get_vars() -> Dictionary:
@@ -325,9 +277,7 @@ class ApiAccountCustom extends NakamaAsyncResult:
 		output += "vars: [%s], " % map_string
 		return output
 
-### <summary>
-### Send a device to the server. Used with authenticate/link/unlink and user.
-### </summary>
+# Send a device to the server. Used with authenticate/link/unlink and user.
 class ApiAccountDevice extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -335,17 +285,13 @@ class ApiAccountDevice extends NakamaAsyncResult:
 		"vars": {"name": "_vars", "type": TYPE_DICTIONARY, "required": false},
 	}
 
-	### <summary>
-	### A device identifier. Should be obtained by a platform-specific device API.
-	### </summary>
+	# A device identifier. Should be obtained by a platform-specific device API.
 	var id : String setget , _get_id
 	var _id = null
 	func _get_id() -> String:
 		return "" if not _id is String else String(_id)
 
-	### <summary>
-	### Extra information that will be bundled in the session token.
-	### </summary>
+	# Extra information that will be bundled in the session token.
 	var vars : Dictionary setget , _get_vars
 	var _vars = null
 	func _get_vars() -> Dictionary:
@@ -372,9 +318,7 @@ class ApiAccountDevice extends NakamaAsyncResult:
 		output += "vars: [%s], " % map_string
 		return output
 
-### <summary>
-### Send an email with password to the server. Used with authenticate/link/unlink.
-### </summary>
+# Send an email with password to the server. Used with authenticate/link/unlink.
 class ApiAccountEmail extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -383,25 +327,19 @@ class ApiAccountEmail extends NakamaAsyncResult:
 		"vars": {"name": "_vars", "type": TYPE_DICTIONARY, "required": false},
 	}
 
-	### <summary>
-	### A valid RFC-5322 email address.
-	### </summary>
+	# A valid RFC-5322 email address.
 	var email : String setget , _get_email
 	var _email = null
 	func _get_email() -> String:
 		return "" if not _email is String else String(_email)
 
-	### <summary>
-	### A password for the user account.
-	### </summary>
+	# A password for the user account.
 	var password : String setget , _get_password
 	var _password = null
 	func _get_password() -> String:
 		return "" if not _password is String else String(_password)
 
-	### <summary>
-	### Extra information that will be bundled in the session token.
-	### </summary>
+	# Extra information that will be bundled in the session token.
 	var vars : Dictionary setget , _get_vars
 	var _vars = null
 	func _get_vars() -> Dictionary:
@@ -429,9 +367,7 @@ class ApiAccountEmail extends NakamaAsyncResult:
 		output += "vars: [%s], " % map_string
 		return output
 
-### <summary>
-### Send a Facebook token to the server. Used with authenticate/link/unlink.
-### </summary>
+# Send a Facebook token to the server. Used with authenticate/link/unlink.
 class ApiAccountFacebook extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -439,17 +375,13 @@ class ApiAccountFacebook extends NakamaAsyncResult:
 		"vars": {"name": "_vars", "type": TYPE_DICTIONARY, "required": false},
 	}
 
-	### <summary>
-	### The OAuth token received from Facebook to access their profile API.
-	### </summary>
+	# The OAuth token received from Facebook to access their profile API.
 	var token : String setget , _get_token
 	var _token = null
 	func _get_token() -> String:
 		return "" if not _token is String else String(_token)
 
-	### <summary>
-	### Extra information that will be bundled in the session token.
-	### </summary>
+	# Extra information that will be bundled in the session token.
 	var vars : Dictionary setget , _get_vars
 	var _vars = null
 	func _get_vars() -> Dictionary:
@@ -476,9 +408,48 @@ class ApiAccountFacebook extends NakamaAsyncResult:
 		output += "vars: [%s], " % map_string
 		return output
 
-### <summary>
-### Send Apple's Game Center account credentials to the server. Used with authenticate/link/unlink.
-### </summary>
+# Send a Facebook Instant Game token to the server. Used with authenticate/link/unlink.
+class ApiAccountFacebookInstantGame extends NakamaAsyncResult:
+
+	const _SCHEMA = {
+		"signed_player_info": {"name": "_signed_player_info", "type": TYPE_STRING, "required": false},
+		"vars": {"name": "_vars", "type": TYPE_DICTIONARY, "required": false},
+	}
+
+	# 
+	var signed_player_info : String setget , _get_signed_player_info
+	var _signed_player_info = null
+	func _get_signed_player_info() -> String:
+		return "" if not _signed_player_info is String else String(_signed_player_info)
+
+	# Extra information that will be bundled in the session token.
+	var vars : Dictionary setget , _get_vars
+	var _vars = null
+	func _get_vars() -> Dictionary:
+		return Dictionary() if not _vars is Dictionary else _vars.duplicate()
+
+	func _init(p_exception = null).(p_exception):
+		pass
+
+	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiAccountFacebookInstantGame:
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountFacebookInstantGame", p_dict), ApiAccountFacebookInstantGame) as ApiAccountFacebookInstantGame
+
+	func serialize() -> Dictionary:
+		return NakamaSerializer.serialize(self)
+
+	func _to_string() -> String:
+		if is_exception():
+			return get_exception()._to_string()
+		var output : String = ""
+		output += "signed_player_info: %s, " % _signed_player_info
+		var map_string : String = ""
+		if typeof(_vars) == TYPE_DICTIONARY:
+			for k in _vars:
+				map_string += "{%s=%s}, " % [k, _vars[k]]
+		output += "vars: [%s], " % map_string
+		return output
+
+# Send Apple's Game Center account credentials to the server. Used with authenticate/link/unlink.
 class ApiAccountGameCenter extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -491,57 +462,43 @@ class ApiAccountGameCenter extends NakamaAsyncResult:
 		"vars": {"name": "_vars", "type": TYPE_DICTIONARY, "required": false},
 	}
 
-	### <summary>
-	### Bundle ID (generated by GameCenter).
-	### </summary>
+	# Bundle ID (generated by GameCenter).
 	var bundle_id : String setget , _get_bundle_id
 	var _bundle_id = null
 	func _get_bundle_id() -> String:
 		return "" if not _bundle_id is String else String(_bundle_id)
 
-	### <summary>
-	### Player ID (generated by GameCenter).
-	### </summary>
+	# Player ID (generated by GameCenter).
 	var player_id : String setget , _get_player_id
 	var _player_id = null
 	func _get_player_id() -> String:
 		return "" if not _player_id is String else String(_player_id)
 
-	### <summary>
-	### The URL for the public encryption key.
-	### </summary>
+	# The URL for the public encryption key.
 	var public_key_url : String setget , _get_public_key_url
 	var _public_key_url = null
 	func _get_public_key_url() -> String:
 		return "" if not _public_key_url is String else String(_public_key_url)
 
-	### <summary>
-	### A random "NSString" used to compute the hash and keep it randomized.
-	### </summary>
+	# A random `NSString` used to compute the hash and keep it randomized.
 	var salt : String setget , _get_salt
 	var _salt = null
 	func _get_salt() -> String:
 		return "" if not _salt is String else String(_salt)
 
-	### <summary>
-	### The verification signature data generated.
-	### </summary>
+	# The verification signature data generated.
 	var signature : String setget , _get_signature
 	var _signature = null
 	func _get_signature() -> String:
 		return "" if not _signature is String else String(_signature)
 
-	### <summary>
-	### Time since UNIX epoch when the signature was created.
-	### </summary>
+	# Time since UNIX epoch when the signature was created.
 	var timestamp_seconds : String setget , _get_timestamp_seconds
 	var _timestamp_seconds = null
 	func _get_timestamp_seconds() -> String:
 		return "" if not _timestamp_seconds is String else String(_timestamp_seconds)
 
-	### <summary>
-	### Extra information that will be bundled in the session token.
-	### </summary>
+	# Extra information that will be bundled in the session token.
 	var vars : Dictionary setget , _get_vars
 	var _vars = null
 	func _get_vars() -> Dictionary:
@@ -573,9 +530,7 @@ class ApiAccountGameCenter extends NakamaAsyncResult:
 		output += "vars: [%s], " % map_string
 		return output
 
-### <summary>
-### Send a Google token to the server. Used with authenticate/link/unlink.
-### </summary>
+# Send a Google token to the server. Used with authenticate/link/unlink.
 class ApiAccountGoogle extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -583,17 +538,13 @@ class ApiAccountGoogle extends NakamaAsyncResult:
 		"vars": {"name": "_vars", "type": TYPE_DICTIONARY, "required": false},
 	}
 
-	### <summary>
-	### The OAuth token received from Google to access their profile API.
-	### </summary>
+	# The OAuth token received from Google to access their profile API.
 	var token : String setget , _get_token
 	var _token = null
 	func _get_token() -> String:
 		return "" if not _token is String else String(_token)
 
-	### <summary>
-	### Extra information that will be bundled in the session token.
-	### </summary>
+	# Extra information that will be bundled in the session token.
 	var vars : Dictionary setget , _get_vars
 	var _vars = null
 	func _get_vars() -> Dictionary:
@@ -620,9 +571,7 @@ class ApiAccountGoogle extends NakamaAsyncResult:
 		output += "vars: [%s], " % map_string
 		return output
 
-### <summary>
-### Send a Steam token to the server. Used with authenticate/link/unlink.
-### </summary>
+# Send a Steam token to the server. Used with authenticate/link/unlink.
 class ApiAccountSteam extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -630,17 +579,13 @@ class ApiAccountSteam extends NakamaAsyncResult:
 		"vars": {"name": "_vars", "type": TYPE_DICTIONARY, "required": false},
 	}
 
-	### <summary>
-	### The account token received from Steam to access their profile API.
-	### </summary>
+	# The account token received from Steam to access their profile API.
 	var token : String setget , _get_token
 	var _token = null
 	func _get_token() -> String:
 		return "" if not _token is String else String(_token)
 
-	### <summary>
-	### Extra information that will be bundled in the session token.
-	### </summary>
+	# Extra information that will be bundled in the session token.
 	var vars : Dictionary setget , _get_vars
 	var _vars = null
 	func _get_vars() -> Dictionary:
@@ -667,9 +612,7 @@ class ApiAccountSteam extends NakamaAsyncResult:
 		output += "vars: [%s], " % map_string
 		return output
 
-### <summary>
-### A message sent on a channel.
-### </summary>
+# A message sent on a channel.
 class ApiChannelMessage extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -688,105 +631,79 @@ class ApiChannelMessage extends NakamaAsyncResult:
 		"username": {"name": "_username", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### The channel this message belongs to.
-	### </summary>
+	# The channel this message belongs to.
 	var channel_id : String setget , _get_channel_id
 	var _channel_id = null
 	func _get_channel_id() -> String:
 		return "" if not _channel_id is String else String(_channel_id)
 
-	### <summary>
-	### The code representing a message type or category.
-	### </summary>
+	# The code representing a message type or category.
 	var code : int setget , _get_code
 	var _code = null
 	func _get_code() -> int:
 		return 0 if not _code is int else int(_code)
 
-	### <summary>
-	### The content payload.
-	### </summary>
+	# The content payload.
 	var content : String setget , _get_content
 	var _content = null
 	func _get_content() -> String:
 		return "" if not _content is String else String(_content)
 
-	### <summary>
-	### The UNIX time when the message was created.
-	### </summary>
+	# The UNIX time when the message was created.
 	var create_time : String setget , _get_create_time
 	var _create_time = null
 	func _get_create_time() -> String:
 		return "" if not _create_time is String else String(_create_time)
 
-	### <summary>
-	### The ID of the group, or an empty string if this message was not sent through a group channel.
-	### </summary>
+	# The ID of the group, or an empty string if this message was not sent through a group channel.
 	var group_id : String setget , _get_group_id
 	var _group_id = null
 	func _get_group_id() -> String:
 		return "" if not _group_id is String else String(_group_id)
 
-	### <summary>
-	### The unique ID of this message.
-	### </summary>
+	# The unique ID of this message.
 	var message_id : String setget , _get_message_id
 	var _message_id = null
 	func _get_message_id() -> String:
 		return "" if not _message_id is String else String(_message_id)
 
-	### <summary>
-	### True if the message was persisted to the channel's history, false otherwise.
-	### </summary>
+	# True if the message was persisted to the channel's history, false otherwise.
 	var persistent : bool setget , _get_persistent
 	var _persistent = null
 	func _get_persistent() -> bool:
 		return false if not _persistent is bool else bool(_persistent)
 
-	### <summary>
-	### The name of the chat room, or an empty string if this message was not sent through a chat room.
-	### </summary>
+	# The name of the chat room, or an empty string if this message was not sent through a chat room.
 	var room_name : String setget , _get_room_name
 	var _room_name = null
 	func _get_room_name() -> String:
 		return "" if not _room_name is String else String(_room_name)
 
-	### <summary>
-	### Message sender, usually a user ID.
-	### </summary>
+	# Message sender, usually a user ID.
 	var sender_id : String setget , _get_sender_id
 	var _sender_id = null
 	func _get_sender_id() -> String:
 		return "" if not _sender_id is String else String(_sender_id)
 
-	### <summary>
-	### The UNIX time when the message was last updated.
-	### </summary>
+	# The UNIX time when the message was last updated.
 	var update_time : String setget , _get_update_time
 	var _update_time = null
 	func _get_update_time() -> String:
 		return "" if not _update_time is String else String(_update_time)
 
-	### <summary>
-	### The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
-	### </summary>
+	# The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
 	var user_id_one : String setget , _get_user_id_one
 	var _user_id_one = null
 	func _get_user_id_one() -> String:
 		return "" if not _user_id_one is String else String(_user_id_one)
 
-	### <summary>
-	### The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
-	### </summary>
+	# The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
 	var user_id_two : String setget , _get_user_id_two
 	var _user_id_two = null
 	func _get_user_id_two() -> String:
 		return "" if not _user_id_two is String else String(_user_id_two)
 
-	### <summary>
-	### The username of the message sender, if any.
-	### </summary>
+	# The username of the message sender, if any.
 	var username : String setget , _get_username
 	var _username = null
 	func _get_username() -> String:
@@ -820,9 +737,7 @@ class ApiChannelMessage extends NakamaAsyncResult:
 		output += "username: %s, " % _username
 		return output
 
-### <summary>
-### A list of channel messages, usually a result of a list operation.
-### </summary>
+# A list of channel messages, usually a result of a list operation.
 class ApiChannelMessageList extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -831,25 +746,19 @@ class ApiChannelMessageList extends NakamaAsyncResult:
 		"prev_cursor": {"name": "_prev_cursor", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### A list of messages.
-	### </summary>
+	# A list of messages.
 	var messages : Array setget , _get_messages
 	var _messages = null
 	func _get_messages() -> Array:
 		return Array() if not _messages is Array else Array(_messages)
 
-	### <summary>
-	### The cursor to send when retireving the next page, if any.
-	### </summary>
+	# The cursor to send when retireving the next page, if any.
 	var next_cursor : String setget , _get_next_cursor
 	var _next_cursor = null
 	func _get_next_cursor() -> String:
 		return "" if not _next_cursor is String else String(_next_cursor)
 
-	### <summary>
-	### The cursor to send when retrieving the previous page, if any.
-	### </summary>
+	# The cursor to send when retrieving the previous page, if any.
 	var prev_cursor : String setget , _get_prev_cursor
 	var _prev_cursor = null
 	func _get_prev_cursor() -> String:
@@ -873,9 +782,7 @@ class ApiChannelMessageList extends NakamaAsyncResult:
 		output += "prev_cursor: %s, " % _prev_cursor
 		return output
 
-### <summary>
-### Create a group with the current user as owner.
-### </summary>
+# Create a group with the current user as owner.
 class ApiCreateGroupRequest extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -887,49 +794,37 @@ class ApiCreateGroupRequest extends NakamaAsyncResult:
 		"open": {"name": "_open", "type": TYPE_BOOL, "required": false},
 	}
 
-	### <summary>
-	### A URL for an avatar image.
-	### </summary>
+	# A URL for an avatar image.
 	var avatar_url : String setget , _get_avatar_url
 	var _avatar_url = null
 	func _get_avatar_url() -> String:
 		return "" if not _avatar_url is String else String(_avatar_url)
 
-	### <summary>
-	### A description for the group.
-	### </summary>
+	# A description for the group.
 	var description : String setget , _get_description
 	var _description = null
 	func _get_description() -> String:
 		return "" if not _description is String else String(_description)
 
-	### <summary>
-	### The language expected to be a tag which follows the BCP-47 spec.
-	### </summary>
+	# The language expected to be a tag which follows the BCP-47 spec.
 	var lang_tag : String setget , _get_lang_tag
 	var _lang_tag = null
 	func _get_lang_tag() -> String:
 		return "" if not _lang_tag is String else String(_lang_tag)
 
-	### <summary>
-	### Maximum number of group members.
-	### </summary>
+	# Maximum number of group members.
 	var max_count : int setget , _get_max_count
 	var _max_count = null
 	func _get_max_count() -> int:
 		return 0 if not _max_count is int else int(_max_count)
 
-	### <summary>
-	### A unique name for the group.
-	### </summary>
+	# A unique name for the group.
 	var name : String setget , _get_name
 	var _name = null
 	func _get_name() -> String:
 		return "" if not _name is String else String(_name)
 
-	### <summary>
-	### Mark a group as open or not where only admins can accept members.
-	### </summary>
+	# Mark a group as open or not where only admins can accept members.
 	var open : bool setget , _get_open
 	var _open = null
 	func _get_open() -> bool:
@@ -956,9 +851,7 @@ class ApiCreateGroupRequest extends NakamaAsyncResult:
 		output += "open: %s, " % _open
 		return output
 
-### <summary>
-### Storage objects to delete.
-### </summary>
+# Storage objects to delete.
 class ApiDeleteStorageObjectId extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -967,25 +860,19 @@ class ApiDeleteStorageObjectId extends NakamaAsyncResult:
 		"version": {"name": "_version", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### The collection which stores the object.
-	### </summary>
+	# The collection which stores the object.
 	var collection : String setget , _get_collection
 	var _collection = null
 	func _get_collection() -> String:
 		return "" if not _collection is String else String(_collection)
 
-	### <summary>
-	### The key of the object within the collection.
-	### </summary>
+	# The key of the object within the collection.
 	var key : String setget , _get_key
 	var _key = null
 	func _get_key() -> String:
 		return "" if not _key is String else String(_key)
 
-	### <summary>
-	### The version hash of the object.
-	### </summary>
+	# The version hash of the object.
 	var version : String setget , _get_version
 	var _version = null
 	func _get_version() -> String:
@@ -1009,18 +896,14 @@ class ApiDeleteStorageObjectId extends NakamaAsyncResult:
 		output += "version: %s, " % _version
 		return output
 
-### <summary>
-### Batch delete storage objects.
-### </summary>
+# Batch delete storage objects.
 class ApiDeleteStorageObjectsRequest extends NakamaAsyncResult:
 
 	const _SCHEMA = {
 		"object_ids": {"name": "_object_ids", "type": TYPE_ARRAY, "required": false, "content": "ApiDeleteStorageObjectId"},
 	}
 
-	### <summary>
-	### Batch of storage objects.
-	### </summary>
+	# Batch of storage objects.
 	var object_ids : Array setget , _get_object_ids
 	var _object_ids = null
 	func _get_object_ids() -> Array:
@@ -1042,9 +925,7 @@ class ApiDeleteStorageObjectsRequest extends NakamaAsyncResult:
 		output += "object_ids: %s, " % [_object_ids]
 		return output
 
-### <summary>
-### Represents an event to be passed through the server to registered event handlers.
-### </summary>
+# Represents an event to be passed through the server to registered event handlers.
 class ApiEvent extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -1054,33 +935,25 @@ class ApiEvent extends NakamaAsyncResult:
 		"timestamp": {"name": "_timestamp", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### True if the event came directly from a client call, false otherwise.
-	### </summary>
+	# True if the event came directly from a client call, false otherwise.
 	var external : bool setget , _get_external
 	var _external = null
 	func _get_external() -> bool:
 		return false if not _external is bool else bool(_external)
 
-	### <summary>
-	### An event name, type, category, or identifier.
-	### </summary>
+	# An event name, type, category, or identifier.
 	var name : String setget , _get_name
 	var _name = null
 	func _get_name() -> String:
 		return "" if not _name is String else String(_name)
 
-	### <summary>
-	### Arbitrary event property values.
-	### </summary>
+	# Arbitrary event property values.
 	var properties : Dictionary setget , _get_properties
 	var _properties = null
 	func _get_properties() -> Dictionary:
 		return Dictionary() if not _properties is Dictionary else _properties.duplicate()
 
-	### <summary>
-	### The time when the event was triggered.
-	### </summary>
+	# The time when the event was triggered.
 	var timestamp : String setget , _get_timestamp
 	var _timestamp = null
 	func _get_timestamp() -> String:
@@ -1109,9 +982,7 @@ class ApiEvent extends NakamaAsyncResult:
 		output += "timestamp: %s, " % _timestamp
 		return output
 
-### <summary>
-### A friend of a user.
-### </summary>
+# A friend of a user.
 class ApiFriend extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -1119,17 +990,13 @@ class ApiFriend extends NakamaAsyncResult:
 		"user": {"name": "_user", "type": "ApiUser", "required": false},
 	}
 
-	### <summary>
-	### The friend status.
-	### </summary>
+	# The friend status.
 	var state : int setget , _get_state
 	var _state = null
 	func _get_state() -> int:
 		return 0 if not _state is int else int(_state)
 
-	### <summary>
-	### The user object.
-	### </summary>
+	# The user object.
 	var user : ApiUser setget , _get_user
 	var _user = null
 	func _get_user() -> ApiUser:
@@ -1152,9 +1019,7 @@ class ApiFriend extends NakamaAsyncResult:
 		output += "user: %s, " % _user
 		return output
 
-### <summary>
-### A collection of zero or more friends of the user.
-### </summary>
+# A collection of zero or more friends of the user.
 class ApiFriendList extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -1162,17 +1027,13 @@ class ApiFriendList extends NakamaAsyncResult:
 		"friends": {"name": "_friends", "type": TYPE_ARRAY, "required": false, "content": "ApiFriend"},
 	}
 
-	### <summary>
-	### Cursor for the next page of results, if any.
-	### </summary>
+	# Cursor for the next page of results, if any.
 	var cursor : String setget , _get_cursor
 	var _cursor = null
 	func _get_cursor() -> String:
 		return "" if not _cursor is String else String(_cursor)
 
-	### <summary>
-	### The Friend objects.
-	### </summary>
+	# The Friend objects.
 	var friends : Array setget , _get_friends
 	var _friends = null
 	func _get_friends() -> Array:
@@ -1195,9 +1056,7 @@ class ApiFriendList extends NakamaAsyncResult:
 		output += "friends: %s, " % [_friends]
 		return output
 
-### <summary>
-### A group in the server.
-### </summary>
+# A group in the server.
 class ApiGroup extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -1215,97 +1074,73 @@ class ApiGroup extends NakamaAsyncResult:
 		"update_time": {"name": "_update_time", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### A URL for an avatar image.
-	### </summary>
+	# A URL for an avatar image.
 	var avatar_url : String setget , _get_avatar_url
 	var _avatar_url = null
 	func _get_avatar_url() -> String:
 		return "" if not _avatar_url is String else String(_avatar_url)
 
-	### <summary>
-	### The UNIX time when the group was created.
-	### </summary>
+	# The UNIX time when the group was created.
 	var create_time : String setget , _get_create_time
 	var _create_time = null
 	func _get_create_time() -> String:
 		return "" if not _create_time is String else String(_create_time)
 
-	### <summary>
-	### The id of the user who created the group.
-	### </summary>
+	# The id of the user who created the group.
 	var creator_id : String setget , _get_creator_id
 	var _creator_id = null
 	func _get_creator_id() -> String:
 		return "" if not _creator_id is String else String(_creator_id)
 
-	### <summary>
-	### A description for the group.
-	### </summary>
+	# A description for the group.
 	var description : String setget , _get_description
 	var _description = null
 	func _get_description() -> String:
 		return "" if not _description is String else String(_description)
 
-	### <summary>
-	### The current count of all members in the group.
-	### </summary>
+	# The current count of all members in the group.
 	var edge_count : int setget , _get_edge_count
 	var _edge_count = null
 	func _get_edge_count() -> int:
 		return 0 if not _edge_count is int else int(_edge_count)
 
-	### <summary>
-	### The id of a group.
-	### </summary>
+	# The id of a group.
 	var id : String setget , _get_id
 	var _id = null
 	func _get_id() -> String:
 		return "" if not _id is String else String(_id)
 
-	### <summary>
-	### The language expected to be a tag which follows the BCP-47 spec.
-	### </summary>
+	# The language expected to be a tag which follows the BCP-47 spec.
 	var lang_tag : String setget , _get_lang_tag
 	var _lang_tag = null
 	func _get_lang_tag() -> String:
 		return "" if not _lang_tag is String else String(_lang_tag)
 
-	### <summary>
-	### The maximum number of members allowed.
-	### </summary>
+	# The maximum number of members allowed.
 	var max_count : int setget , _get_max_count
 	var _max_count = null
 	func _get_max_count() -> int:
 		return 0 if not _max_count is int else int(_max_count)
 
-	### <summary>
-	### Additional information stored as a JSON object.
-	### </summary>
+	# Additional information stored as a JSON object.
 	var metadata : String setget , _get_metadata
 	var _metadata = null
 	func _get_metadata() -> String:
 		return "" if not _metadata is String else String(_metadata)
 
-	### <summary>
-	### The unique name of the group.
-	### </summary>
+	# The unique name of the group.
 	var name : String setget , _get_name
 	var _name = null
 	func _get_name() -> String:
 		return "" if not _name is String else String(_name)
 
-	### <summary>
-	### Anyone can join open groups, otherwise only admins can accept members.
-	### </summary>
+	# Anyone can join open groups, otherwise only admins can accept members.
 	var open : bool setget , _get_open
 	var _open = null
 	func _get_open() -> bool:
 		return false if not _open is bool else bool(_open)
 
-	### <summary>
-	### The UNIX time when the group was last updated.
-	### </summary>
+	# The UNIX time when the group was last updated.
 	var update_time : String setget , _get_update_time
 	var _update_time = null
 	func _get_update_time() -> String:
@@ -1338,9 +1173,7 @@ class ApiGroup extends NakamaAsyncResult:
 		output += "update_time: %s, " % _update_time
 		return output
 
-### <summary>
-### One or more groups returned from a listing operation.
-### </summary>
+# One or more groups returned from a listing operation.
 class ApiGroupList extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -1348,17 +1181,13 @@ class ApiGroupList extends NakamaAsyncResult:
 		"groups": {"name": "_groups", "type": TYPE_ARRAY, "required": false, "content": "ApiGroup"},
 	}
 
-	### <summary>
-	### A cursor used to get the next page.
-	### </summary>
+	# A cursor used to get the next page.
 	var cursor : String setget , _get_cursor
 	var _cursor = null
 	func _get_cursor() -> String:
 		return "" if not _cursor is String else String(_cursor)
 
-	### <summary>
-	### One or more groups.
-	### </summary>
+	# One or more groups.
 	var groups : Array setget , _get_groups
 	var _groups = null
 	func _get_groups() -> Array:
@@ -1381,9 +1210,7 @@ class ApiGroupList extends NakamaAsyncResult:
 		output += "groups: %s, " % [_groups]
 		return output
 
-### <summary>
-### A list of users belonging to a group, along with their role.
-### </summary>
+# A list of users belonging to a group, along with their role.
 class ApiGroupUserList extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -1391,17 +1218,13 @@ class ApiGroupUserList extends NakamaAsyncResult:
 		"group_users": {"name": "_group_users", "type": TYPE_ARRAY, "required": false, "content": "GroupUserListGroupUser"},
 	}
 
-	### <summary>
-	### Cursor for the next page of results, if any.
-	### </summary>
+	# Cursor for the next page of results, if any.
 	var cursor : String setget , _get_cursor
 	var _cursor = null
 	func _get_cursor() -> String:
 		return "" if not _cursor is String else String(_cursor)
 
-	### <summary>
-	### User-role pairs for a group.
-	### </summary>
+	# User-role pairs for a group.
 	var group_users : Array setget , _get_group_users
 	var _group_users = null
 	func _get_group_users() -> Array:
@@ -1424,9 +1247,7 @@ class ApiGroupUserList extends NakamaAsyncResult:
 		output += "group_users: %s, " % [_group_users]
 		return output
 
-### <summary>
-### Represents a complete leaderboard record with all scores and associated metadata.
-### </summary>
+# Represents a complete leaderboard record with all scores and associated metadata.
 class ApiLeaderboardRecord extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -1444,97 +1265,73 @@ class ApiLeaderboardRecord extends NakamaAsyncResult:
 		"username": {"name": "_username", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### The UNIX time when the leaderboard record was created.
-	### </summary>
+	# The UNIX time when the leaderboard record was created.
 	var create_time : String setget , _get_create_time
 	var _create_time = null
 	func _get_create_time() -> String:
 		return "" if not _create_time is String else String(_create_time)
 
-	### <summary>
-	### The UNIX time when the leaderboard record expires.
-	### </summary>
+	# The UNIX time when the leaderboard record expires.
 	var expiry_time : String setget , _get_expiry_time
 	var _expiry_time = null
 	func _get_expiry_time() -> String:
 		return "" if not _expiry_time is String else String(_expiry_time)
 
-	### <summary>
-	### The ID of the leaderboard this score belongs to.
-	### </summary>
+	# The ID of the leaderboard this score belongs to.
 	var leaderboard_id : String setget , _get_leaderboard_id
 	var _leaderboard_id = null
 	func _get_leaderboard_id() -> String:
 		return "" if not _leaderboard_id is String else String(_leaderboard_id)
 
-	### <summary>
-	### The maximum number of score updates allowed by the owner.
-	### </summary>
+	# The maximum number of score updates allowed by the owner.
 	var max_num_score : int setget , _get_max_num_score
 	var _max_num_score = null
 	func _get_max_num_score() -> int:
 		return 0 if not _max_num_score is int else int(_max_num_score)
 
-	### <summary>
-	### Metadata.
-	### </summary>
+	# Metadata.
 	var metadata : String setget , _get_metadata
 	var _metadata = null
 	func _get_metadata() -> String:
 		return "" if not _metadata is String else String(_metadata)
 
-	### <summary>
-	### The number of submissions to this score record.
-	### </summary>
+	# The number of submissions to this score record.
 	var num_score : int setget , _get_num_score
 	var _num_score = null
 	func _get_num_score() -> int:
 		return 0 if not _num_score is int else int(_num_score)
 
-	### <summary>
-	### The ID of the score owner, usually a user or group.
-	### </summary>
+	# The ID of the score owner, usually a user or group.
 	var owner_id : String setget , _get_owner_id
 	var _owner_id = null
 	func _get_owner_id() -> String:
 		return "" if not _owner_id is String else String(_owner_id)
 
-	### <summary>
-	### The rank of this record.
-	### </summary>
+	# The rank of this record.
 	var rank : String setget , _get_rank
 	var _rank = null
 	func _get_rank() -> String:
 		return "" if not _rank is String else String(_rank)
 
-	### <summary>
-	### The score value.
-	### </summary>
+	# The score value.
 	var score : String setget , _get_score
 	var _score = null
 	func _get_score() -> String:
 		return "" if not _score is String else String(_score)
 
-	### <summary>
-	### An optional subscore value.
-	### </summary>
+	# An optional subscore value.
 	var subscore : String setget , _get_subscore
 	var _subscore = null
 	func _get_subscore() -> String:
 		return "" if not _subscore is String else String(_subscore)
 
-	### <summary>
-	### The UNIX time when the leaderboard record was updated.
-	### </summary>
+	# The UNIX time when the leaderboard record was updated.
 	var update_time : String setget , _get_update_time
 	var _update_time = null
 	func _get_update_time() -> String:
 		return "" if not _update_time is String else String(_update_time)
 
-	### <summary>
-	### The username of the score owner, if the owner is a user.
-	### </summary>
+	# The username of the score owner, if the owner is a user.
 	var username : String setget , _get_username
 	var _username = null
 	func _get_username() -> String:
@@ -1567,9 +1364,7 @@ class ApiLeaderboardRecord extends NakamaAsyncResult:
 		output += "username: %s, " % _username
 		return output
 
-### <summary>
-### A set of leaderboard records, may be part of a leaderboard records page or a batch of individual records.
-### </summary>
+# A set of leaderboard records, may be part of a leaderboard records page or a batch of individual records.
 class ApiLeaderboardRecordList extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -1579,33 +1374,25 @@ class ApiLeaderboardRecordList extends NakamaAsyncResult:
 		"records": {"name": "_records", "type": TYPE_ARRAY, "required": false, "content": "ApiLeaderboardRecord"},
 	}
 
-	### <summary>
-	### The cursor to send when retrieving the next page, if any.
-	### </summary>
+	# The cursor to send when retrieving the next page, if any.
 	var next_cursor : String setget , _get_next_cursor
 	var _next_cursor = null
 	func _get_next_cursor() -> String:
 		return "" if not _next_cursor is String else String(_next_cursor)
 
-	### <summary>
-	### A batched set of leaderboard records belonging to specified owners.
-	### </summary>
+	# A batched set of leaderboard records belonging to specified owners.
 	var owner_records : Array setget , _get_owner_records
 	var _owner_records = null
 	func _get_owner_records() -> Array:
 		return Array() if not _owner_records is Array else Array(_owner_records)
 
-	### <summary>
-	### The cursor to send when retrieving the previous page, if any.
-	### </summary>
+	# The cursor to send when retrieving the previous page, if any.
 	var prev_cursor : String setget , _get_prev_cursor
 	var _prev_cursor = null
 	func _get_prev_cursor() -> String:
 		return "" if not _prev_cursor is String else String(_prev_cursor)
 
-	### <summary>
-	### A list of leaderboard records.
-	### </summary>
+	# A list of leaderboard records.
 	var records : Array setget , _get_records
 	var _records = null
 	func _get_records() -> Array:
@@ -1630,9 +1417,7 @@ class ApiLeaderboardRecordList extends NakamaAsyncResult:
 		output += "records: %s, " % [_records]
 		return output
 
-### <summary>
-### Represents a realtime match.
-### </summary>
+# Represents a realtime match.
 class ApiMatch extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -1642,33 +1427,25 @@ class ApiMatch extends NakamaAsyncResult:
 		"size": {"name": "_size", "type": TYPE_INT, "required": false},
 	}
 
-	### <summary>
-	### True if it's an server-managed authoritative match, false otherwise.
-	### </summary>
+	# True if it's an server-managed authoritative match, false otherwise.
 	var authoritative : bool setget , _get_authoritative
 	var _authoritative = null
 	func _get_authoritative() -> bool:
 		return false if not _authoritative is bool else bool(_authoritative)
 
-	### <summary>
-	### Match label, if any.
-	### </summary>
+	# Match label, if any.
 	var label : String setget , _get_label
 	var _label = null
 	func _get_label() -> String:
 		return "" if not _label is String else String(_label)
 
-	### <summary>
-	### The ID of the match, can be used to join.
-	### </summary>
+	# The ID of the match, can be used to join.
 	var match_id : String setget , _get_match_id
 	var _match_id = null
 	func _get_match_id() -> String:
 		return "" if not _match_id is String else String(_match_id)
 
-	### <summary>
-	### Current number of users in the match.
-	### </summary>
+	# Current number of users in the match.
 	var size : int setget , _get_size
 	var _size = null
 	func _get_size() -> int:
@@ -1693,18 +1470,14 @@ class ApiMatch extends NakamaAsyncResult:
 		output += "size: %s, " % _size
 		return output
 
-### <summary>
-### A list of realtime matches.
-### </summary>
+# A list of realtime matches.
 class ApiMatchList extends NakamaAsyncResult:
 
 	const _SCHEMA = {
 		"matches": {"name": "_matches", "type": TYPE_ARRAY, "required": false, "content": "ApiMatch"},
 	}
 
-	### <summary>
-	### A number of matches corresponding to a list operation.
-	### </summary>
+	# A number of matches corresponding to a list operation.
 	var matches : Array setget , _get_matches
 	var _matches = null
 	func _get_matches() -> Array:
@@ -1726,9 +1499,7 @@ class ApiMatchList extends NakamaAsyncResult:
 		output += "matches: %s, " % [_matches]
 		return output
 
-### <summary>
-### A notification in the server.
-### </summary>
+# A notification in the server.
 class ApiNotification extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -1741,57 +1512,43 @@ class ApiNotification extends NakamaAsyncResult:
 		"subject": {"name": "_subject", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### Category code for this notification.
-	### </summary>
+	# Category code for this notification.
 	var code : int setget , _get_code
 	var _code = null
 	func _get_code() -> int:
 		return 0 if not _code is int else int(_code)
 
-	### <summary>
-	### Content of the notification in JSON.
-	### </summary>
+	# Content of the notification in JSON.
 	var content : String setget , _get_content
 	var _content = null
 	func _get_content() -> String:
 		return "" if not _content is String else String(_content)
 
-	### <summary>
-	### The UNIX time when the notification was created.
-	### </summary>
+	# The UNIX time when the notification was created.
 	var create_time : String setget , _get_create_time
 	var _create_time = null
 	func _get_create_time() -> String:
 		return "" if not _create_time is String else String(_create_time)
 
-	### <summary>
-	### ID of the Notification.
-	### </summary>
+	# ID of the Notification.
 	var id : String setget , _get_id
 	var _id = null
 	func _get_id() -> String:
 		return "" if not _id is String else String(_id)
 
-	### <summary>
-	### True if this notification was persisted to the database.
-	### </summary>
+	# True if this notification was persisted to the database.
 	var persistent : bool setget , _get_persistent
 	var _persistent = null
 	func _get_persistent() -> bool:
 		return false if not _persistent is bool else bool(_persistent)
 
-	### <summary>
-	### ID of the sender, if a user. Otherwise 'null'.
-	### </summary>
+	# ID of the sender, if a user. Otherwise `null`.
 	var sender_id : String setget , _get_sender_id
 	var _sender_id = null
 	func _get_sender_id() -> String:
 		return "" if not _sender_id is String else String(_sender_id)
 
-	### <summary>
-	### Subject of the notification.
-	### </summary>
+	# Subject of the notification.
 	var subject : String setget , _get_subject
 	var _subject = null
 	func _get_subject() -> String:
@@ -1819,9 +1576,7 @@ class ApiNotification extends NakamaAsyncResult:
 		output += "subject: %s, " % _subject
 		return output
 
-### <summary>
-### A collection of zero or more notifications.
-### </summary>
+# A collection of zero or more notifications.
 class ApiNotificationList extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -1829,17 +1584,13 @@ class ApiNotificationList extends NakamaAsyncResult:
 		"notifications": {"name": "_notifications", "type": TYPE_ARRAY, "required": false, "content": "ApiNotification"},
 	}
 
-	### <summary>
-	### Use this cursor to paginate notifications. Cache this to catch up to new notifications.
-	### </summary>
+	# Use this cursor to paginate notifications. Cache this to catch up to new notifications.
 	var cacheable_cursor : String setget , _get_cacheable_cursor
 	var _cacheable_cursor = null
 	func _get_cacheable_cursor() -> String:
 		return "" if not _cacheable_cursor is String else String(_cacheable_cursor)
 
-	### <summary>
-	### Collection of notifications.
-	### </summary>
+	# Collection of notifications.
 	var notifications : Array setget , _get_notifications
 	var _notifications = null
 	func _get_notifications() -> Array:
@@ -1862,9 +1613,7 @@ class ApiNotificationList extends NakamaAsyncResult:
 		output += "notifications: %s, " % [_notifications]
 		return output
 
-### <summary>
-### Storage objects to get.
-### </summary>
+# Storage objects to get.
 class ApiReadStorageObjectId extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -1873,25 +1622,19 @@ class ApiReadStorageObjectId extends NakamaAsyncResult:
 		"user_id": {"name": "_user_id", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### The collection which stores the object.
-	### </summary>
+	# The collection which stores the object.
 	var collection : String setget , _get_collection
 	var _collection = null
 	func _get_collection() -> String:
 		return "" if not _collection is String else String(_collection)
 
-	### <summary>
-	### The key of the object within the collection.
-	### </summary>
+	# The key of the object within the collection.
 	var key : String setget , _get_key
 	var _key = null
 	func _get_key() -> String:
 		return "" if not _key is String else String(_key)
 
-	### <summary>
-	### The user owner of the object.
-	### </summary>
+	# The user owner of the object.
 	var user_id : String setget , _get_user_id
 	var _user_id = null
 	func _get_user_id() -> String:
@@ -1915,18 +1658,14 @@ class ApiReadStorageObjectId extends NakamaAsyncResult:
 		output += "user_id: %s, " % _user_id
 		return output
 
-### <summary>
-### Batch get storage objects.
-### </summary>
+# Batch get storage objects.
 class ApiReadStorageObjectsRequest extends NakamaAsyncResult:
 
 	const _SCHEMA = {
 		"object_ids": {"name": "_object_ids", "type": TYPE_ARRAY, "required": false, "content": "ApiReadStorageObjectId"},
 	}
 
-	### <summary>
-	### Batch of storage objects.
-	### </summary>
+	# Batch of storage objects.
 	var object_ids : Array setget , _get_object_ids
 	var _object_ids = null
 	func _get_object_ids() -> Array:
@@ -1948,9 +1687,7 @@ class ApiReadStorageObjectsRequest extends NakamaAsyncResult:
 		output += "object_ids: %s, " % [_object_ids]
 		return output
 
-### <summary>
-### Execute an Lua function on the server.
-### </summary>
+# Execute an Lua function on the server.
 class ApiRpc extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -1959,25 +1696,19 @@ class ApiRpc extends NakamaAsyncResult:
 		"payload": {"name": "_payload", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### The authentication key used when executed as a non-client HTTP request.
-	### </summary>
+	# The authentication key used when executed as a non-client HTTP request.
 	var http_key : String setget , _get_http_key
 	var _http_key = null
 	func _get_http_key() -> String:
 		return "" if not _http_key is String else String(_http_key)
 
-	### <summary>
-	### The identifier of the function.
-	### </summary>
+	# The identifier of the function.
 	var id : String setget , _get_id
 	var _id = null
 	func _get_id() -> String:
 		return "" if not _id is String else String(_id)
 
-	### <summary>
-	### The payload of the function which must be a JSON object.
-	### </summary>
+	# The payload of the function which must be a JSON object.
 	var payload : String setget , _get_payload
 	var _payload = null
 	func _get_payload() -> String:
@@ -2001,9 +1732,7 @@ class ApiRpc extends NakamaAsyncResult:
 		output += "payload: %s, " % _payload
 		return output
 
-### <summary>
-### A user's session used to authenticate messages.
-### </summary>
+# A user's session used to authenticate messages.
 class ApiSession extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -2011,17 +1740,13 @@ class ApiSession extends NakamaAsyncResult:
 		"token": {"name": "_token", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### True if the corresponding account was just created, false otherwise.
-	### </summary>
+	# True if the corresponding account was just created, false otherwise.
 	var created : bool setget , _get_created
 	var _created = null
 	func _get_created() -> bool:
 		return false if not _created is bool else bool(_created)
 
-	### <summary>
-	### Authentication credentials.
-	### </summary>
+	# Authentication credentials.
 	var token : String setget , _get_token
 	var _token = null
 	func _get_token() -> String:
@@ -2044,9 +1769,7 @@ class ApiSession extends NakamaAsyncResult:
 		output += "token: %s, " % _token
 		return output
 
-### <summary>
-### An object within the storage engine.
-### </summary>
+# An object within the storage engine.
 class ApiStorageObject extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -2061,73 +1784,55 @@ class ApiStorageObject extends NakamaAsyncResult:
 		"version": {"name": "_version", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### The collection which stores the object.
-	### </summary>
+	# The collection which stores the object.
 	var collection : String setget , _get_collection
 	var _collection = null
 	func _get_collection() -> String:
 		return "" if not _collection is String else String(_collection)
 
-	### <summary>
-	### The UNIX time when the object was created.
-	### </summary>
+	# The UNIX time when the object was created.
 	var create_time : String setget , _get_create_time
 	var _create_time = null
 	func _get_create_time() -> String:
 		return "" if not _create_time is String else String(_create_time)
 
-	### <summary>
-	### The key of the object within the collection.
-	### </summary>
+	# The key of the object within the collection.
 	var key : String setget , _get_key
 	var _key = null
 	func _get_key() -> String:
 		return "" if not _key is String else String(_key)
 
-	### <summary>
-	### The read access permissions for the object.
-	### </summary>
+	# The read access permissions for the object.
 	var permission_read : int setget , _get_permission_read
 	var _permission_read = null
 	func _get_permission_read() -> int:
 		return 0 if not _permission_read is int else int(_permission_read)
 
-	### <summary>
-	### The write access permissions for the object.
-	### </summary>
+	# The write access permissions for the object.
 	var permission_write : int setget , _get_permission_write
 	var _permission_write = null
 	func _get_permission_write() -> int:
 		return 0 if not _permission_write is int else int(_permission_write)
 
-	### <summary>
-	### The UNIX time when the object was last updated.
-	### </summary>
+	# The UNIX time when the object was last updated.
 	var update_time : String setget , _get_update_time
 	var _update_time = null
 	func _get_update_time() -> String:
 		return "" if not _update_time is String else String(_update_time)
 
-	### <summary>
-	### The user owner of the object.
-	### </summary>
+	# The user owner of the object.
 	var user_id : String setget , _get_user_id
 	var _user_id = null
 	func _get_user_id() -> String:
 		return "" if not _user_id is String else String(_user_id)
 
-	### <summary>
-	### The value of the object.
-	### </summary>
+	# The value of the object.
 	var value : String setget , _get_value
 	var _value = null
 	func _get_value() -> String:
 		return "" if not _value is String else String(_value)
 
-	### <summary>
-	### The version hash of the object.
-	### </summary>
+	# The version hash of the object.
 	var version : String setget , _get_version
 	var _version = null
 	func _get_version() -> String:
@@ -2157,9 +1862,7 @@ class ApiStorageObject extends NakamaAsyncResult:
 		output += "version: %s, " % _version
 		return output
 
-### <summary>
-### A storage acknowledgement.
-### </summary>
+# A storage acknowledgement.
 class ApiStorageObjectAck extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -2169,33 +1872,25 @@ class ApiStorageObjectAck extends NakamaAsyncResult:
 		"version": {"name": "_version", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### The collection which stores the object.
-	### </summary>
+	# The collection which stores the object.
 	var collection : String setget , _get_collection
 	var _collection = null
 	func _get_collection() -> String:
 		return "" if not _collection is String else String(_collection)
 
-	### <summary>
-	### The key of the object within the collection.
-	### </summary>
+	# The key of the object within the collection.
 	var key : String setget , _get_key
 	var _key = null
 	func _get_key() -> String:
 		return "" if not _key is String else String(_key)
 
-	### <summary>
-	### The owner of the object.
-	### </summary>
+	# The owner of the object.
 	var user_id : String setget , _get_user_id
 	var _user_id = null
 	func _get_user_id() -> String:
 		return "" if not _user_id is String else String(_user_id)
 
-	### <summary>
-	### The version hash of the object.
-	### </summary>
+	# The version hash of the object.
 	var version : String setget , _get_version
 	var _version = null
 	func _get_version() -> String:
@@ -2220,18 +1915,14 @@ class ApiStorageObjectAck extends NakamaAsyncResult:
 		output += "version: %s, " % _version
 		return output
 
-### <summary>
-### Batch of acknowledgements for the storage object write.
-### </summary>
+# Batch of acknowledgements for the storage object write.
 class ApiStorageObjectAcks extends NakamaAsyncResult:
 
 	const _SCHEMA = {
 		"acks": {"name": "_acks", "type": TYPE_ARRAY, "required": false, "content": "ApiStorageObjectAck"},
 	}
 
-	### <summary>
-	### Batch of storage write acknowledgements.
-	### </summary>
+	# Batch of storage write acknowledgements.
 	var acks : Array setget , _get_acks
 	var _acks = null
 	func _get_acks() -> Array:
@@ -2253,9 +1944,7 @@ class ApiStorageObjectAcks extends NakamaAsyncResult:
 		output += "acks: %s, " % [_acks]
 		return output
 
-### <summary>
-### List of storage objects.
-### </summary>
+# List of storage objects.
 class ApiStorageObjectList extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -2263,17 +1952,13 @@ class ApiStorageObjectList extends NakamaAsyncResult:
 		"objects": {"name": "_objects", "type": TYPE_ARRAY, "required": false, "content": "ApiStorageObject"},
 	}
 
-	### <summary>
-	### The cursor for the next page of results, if any.
-	### </summary>
+	# The cursor for the next page of results, if any.
 	var cursor : String setget , _get_cursor
 	var _cursor = null
 	func _get_cursor() -> String:
 		return "" if not _cursor is String else String(_cursor)
 
-	### <summary>
-	### The list of storage objects.
-	### </summary>
+	# The list of storage objects.
 	var objects : Array setget , _get_objects
 	var _objects = null
 	func _get_objects() -> Array:
@@ -2296,18 +1981,14 @@ class ApiStorageObjectList extends NakamaAsyncResult:
 		output += "objects: %s, " % [_objects]
 		return output
 
-### <summary>
-### Batch of storage objects.
-### </summary>
+# Batch of storage objects.
 class ApiStorageObjects extends NakamaAsyncResult:
 
 	const _SCHEMA = {
 		"objects": {"name": "_objects", "type": TYPE_ARRAY, "required": false, "content": "ApiStorageObject"},
 	}
 
-	### <summary>
-	### The batch of storage objects.
-	### </summary>
+	# The batch of storage objects.
 	var objects : Array setget , _get_objects
 	var _objects = null
 	func _get_objects() -> Array:
@@ -2329,9 +2010,7 @@ class ApiStorageObjects extends NakamaAsyncResult:
 		output += "objects: %s, " % [_objects]
 		return output
 
-### <summary>
-### A tournament on the server.
-### </summary>
+# A tournament on the server.
 class ApiTournament extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -2354,137 +2033,103 @@ class ApiTournament extends NakamaAsyncResult:
 		"title": {"name": "_title", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### True if the tournament is active and can enter. A computed value.
-	### </summary>
+	# True if the tournament is active and can enter. A computed value.
 	var can_enter : bool setget , _get_can_enter
 	var _can_enter = null
 	func _get_can_enter() -> bool:
 		return false if not _can_enter is bool else bool(_can_enter)
 
-	### <summary>
-	### The category of the tournament. e.g. "vip" could be category 1.
-	### </summary>
+	# The category of the tournament. e.g. "vip" could be category 1.
 	var category : int setget , _get_category
 	var _category = null
 	func _get_category() -> int:
 		return 0 if not _category is int else int(_category)
 
-	### <summary>
-	### The UNIX time when the tournament was created.
-	### </summary>
+	# The UNIX time when the tournament was created.
 	var create_time : String setget , _get_create_time
 	var _create_time = null
 	func _get_create_time() -> String:
 		return "" if not _create_time is String else String(_create_time)
 
-	### <summary>
-	### The description of the tournament. May be blank.
-	### </summary>
+	# The description of the tournament. May be blank.
 	var description : String setget , _get_description
 	var _description = null
 	func _get_description() -> String:
 		return "" if not _description is String else String(_description)
 
-	### <summary>
-	### Duration of the tournament in seconds.
-	### </summary>
+	# Duration of the tournament in seconds.
 	var duration : int setget , _get_duration
 	var _duration = null
 	func _get_duration() -> int:
 		return 0 if not _duration is int else int(_duration)
 
-	### <summary>
-	### The UNIX time when the tournament stops being active until next reset. A computed value.
-	### </summary>
+	# The UNIX time when the tournament stops being active until next reset. A computed value.
 	var end_active : int setget , _get_end_active
 	var _end_active = null
 	func _get_end_active() -> int:
 		return 0 if not _end_active is int else int(_end_active)
 
-	### <summary>
-	### The UNIX time when the tournament will be stopped.
-	### </summary>
+	# The UNIX time when the tournament will be stopped.
 	var end_time : String setget , _get_end_time
 	var _end_time = null
 	func _get_end_time() -> String:
 		return "" if not _end_time is String else String(_end_time)
 
-	### <summary>
-	### The ID of the tournament.
-	### </summary>
+	# The ID of the tournament.
 	var id : String setget , _get_id
 	var _id = null
 	func _get_id() -> String:
 		return "" if not _id is String else String(_id)
 
-	### <summary>
-	### The maximum score updates allowed per player for the current tournament.
-	### </summary>
+	# The maximum score updates allowed per player for the current tournament.
 	var max_num_score : int setget , _get_max_num_score
 	var _max_num_score = null
 	func _get_max_num_score() -> int:
 		return 0 if not _max_num_score is int else int(_max_num_score)
 
-	### <summary>
-	### The maximum number of players for the tournament.
-	### </summary>
+	# The maximum number of players for the tournament.
 	var max_size : int setget , _get_max_size
 	var _max_size = null
 	func _get_max_size() -> int:
 		return 0 if not _max_size is int else int(_max_size)
 
-	### <summary>
-	### Additional information stored as a JSON object.
-	### </summary>
+	# Additional information stored as a JSON object.
 	var metadata : String setget , _get_metadata
 	var _metadata = null
 	func _get_metadata() -> String:
 		return "" if not _metadata is String else String(_metadata)
 
-	### <summary>
-	### The UNIX time when the tournament is next playable. A computed value.
-	### </summary>
+	# The UNIX time when the tournament is next playable. A computed value.
 	var next_reset : int setget , _get_next_reset
 	var _next_reset = null
 	func _get_next_reset() -> int:
 		return 0 if not _next_reset is int else int(_next_reset)
 
-	### <summary>
-	### The current number of players in the tournament.
-	### </summary>
+	# The current number of players in the tournament.
 	var size : int setget , _get_size
 	var _size = null
 	func _get_size() -> int:
 		return 0 if not _size is int else int(_size)
 
-	### <summary>
-	### ASC or DESC sort mode of scores in the tournament.
-	### </summary>
+	# ASC or DESC sort mode of scores in the tournament.
 	var sort_order : int setget , _get_sort_order
 	var _sort_order = null
 	func _get_sort_order() -> int:
 		return 0 if not _sort_order is int else int(_sort_order)
 
-	### <summary>
-	### The UNIX time when the tournament start being active. A computed value.
-	### </summary>
+	# The UNIX time when the tournament start being active. A computed value.
 	var start_active : int setget , _get_start_active
 	var _start_active = null
 	func _get_start_active() -> int:
 		return 0 if not _start_active is int else int(_start_active)
 
-	### <summary>
-	### The UNIX time when the tournament will start.
-	### </summary>
+	# The UNIX time when the tournament will start.
 	var start_time : String setget , _get_start_time
 	var _start_time = null
 	func _get_start_time() -> String:
 		return "" if not _start_time is String else String(_start_time)
 
-	### <summary>
-	### The title for the tournament.
-	### </summary>
+	# The title for the tournament.
 	var title : String setget , _get_title
 	var _title = null
 	func _get_title() -> String:
@@ -2522,9 +2167,7 @@ class ApiTournament extends NakamaAsyncResult:
 		output += "title: %s, " % _title
 		return output
 
-### <summary>
-### A list of tournaments.
-### </summary>
+# A list of tournaments.
 class ApiTournamentList extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -2532,17 +2175,13 @@ class ApiTournamentList extends NakamaAsyncResult:
 		"tournaments": {"name": "_tournaments", "type": TYPE_ARRAY, "required": false, "content": "ApiTournament"},
 	}
 
-	### <summary>
-	### A pagination cursor (optional).
-	### </summary>
+	# A pagination cursor (optional).
 	var cursor : String setget , _get_cursor
 	var _cursor = null
 	func _get_cursor() -> String:
 		return "" if not _cursor is String else String(_cursor)
 
-	### <summary>
-	### The list of tournaments returned.
-	### </summary>
+	# The list of tournaments returned.
 	var tournaments : Array setget , _get_tournaments
 	var _tournaments = null
 	func _get_tournaments() -> Array:
@@ -2565,9 +2204,7 @@ class ApiTournamentList extends NakamaAsyncResult:
 		output += "tournaments: %s, " % [_tournaments]
 		return output
 
-### <summary>
-### A set of tournament records which may be part of a tournament records page or a batch of individual records.
-### </summary>
+# A set of tournament records which may be part of a tournament records page or a batch of individual records.
 class ApiTournamentRecordList extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -2577,33 +2214,25 @@ class ApiTournamentRecordList extends NakamaAsyncResult:
 		"records": {"name": "_records", "type": TYPE_ARRAY, "required": false, "content": "ApiLeaderboardRecord"},
 	}
 
-	### <summary>
-	### The cursor to send when retireving the next page (optional).
-	### </summary>
+	# The cursor to send when retireving the next page (optional).
 	var next_cursor : String setget , _get_next_cursor
 	var _next_cursor = null
 	func _get_next_cursor() -> String:
 		return "" if not _next_cursor is String else String(_next_cursor)
 
-	### <summary>
-	### A batched set of tournament records belonging to specified owners.
-	### </summary>
+	# A batched set of tournament records belonging to specified owners.
 	var owner_records : Array setget , _get_owner_records
 	var _owner_records = null
 	func _get_owner_records() -> Array:
 		return Array() if not _owner_records is Array else Array(_owner_records)
 
-	### <summary>
-	### The cursor to send when retrieving the previous page (optional).
-	### </summary>
+	# The cursor to send when retrieving the previous page (optional).
 	var prev_cursor : String setget , _get_prev_cursor
 	var _prev_cursor = null
 	func _get_prev_cursor() -> String:
 		return "" if not _prev_cursor is String else String(_prev_cursor)
 
-	### <summary>
-	### A list of tournament records.
-	### </summary>
+	# A list of tournament records.
 	var records : Array setget , _get_records
 	var _records = null
 	func _get_records() -> Array:
@@ -2628,9 +2257,7 @@ class ApiTournamentRecordList extends NakamaAsyncResult:
 		output += "records: %s, " % [_records]
 		return output
 
-### <summary>
-### Update a user's account details.
-### </summary>
+# Update a user's account details.
 class ApiUpdateAccountRequest extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -2642,49 +2269,37 @@ class ApiUpdateAccountRequest extends NakamaAsyncResult:
 		"username": {"name": "_username", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### A URL for an avatar image.
-	### </summary>
+	# A URL for an avatar image.
 	var avatar_url : String setget , _get_avatar_url
 	var _avatar_url = null
 	func _get_avatar_url() -> String:
 		return "" if not _avatar_url is String else String(_avatar_url)
 
-	### <summary>
-	### The display name of the user.
-	### </summary>
+	# The display name of the user.
 	var display_name : String setget , _get_display_name
 	var _display_name = null
 	func _get_display_name() -> String:
 		return "" if not _display_name is String else String(_display_name)
 
-	### <summary>
-	### The language expected to be a tag which follows the BCP-47 spec.
-	### </summary>
+	# The language expected to be a tag which follows the BCP-47 spec.
 	var lang_tag : String setget , _get_lang_tag
 	var _lang_tag = null
 	func _get_lang_tag() -> String:
 		return "" if not _lang_tag is String else String(_lang_tag)
 
-	### <summary>
-	### The location set by the user.
-	### </summary>
+	# The location set by the user.
 	var location : String setget , _get_location
 	var _location = null
 	func _get_location() -> String:
 		return "" if not _location is String else String(_location)
 
-	### <summary>
-	### The timezone set by the user.
-	### </summary>
+	# The timezone set by the user.
 	var timezone : String setget , _get_timezone
 	var _timezone = null
 	func _get_timezone() -> String:
 		return "" if not _timezone is String else String(_timezone)
 
-	### <summary>
-	### The username of the user's account.
-	### </summary>
+	# The username of the user's account.
 	var username : String setget , _get_username
 	var _username = null
 	func _get_username() -> String:
@@ -2711,9 +2326,7 @@ class ApiUpdateAccountRequest extends NakamaAsyncResult:
 		output += "username: %s, " % _username
 		return output
 
-### <summary>
-### Update fields in a given group.
-### </summary>
+# Update fields in a given group.
 class ApiUpdateGroupRequest extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -2725,49 +2338,37 @@ class ApiUpdateGroupRequest extends NakamaAsyncResult:
 		"open": {"name": "_open", "type": TYPE_BOOL, "required": false},
 	}
 
-	### <summary>
-	### Avatar URL.
-	### </summary>
+	# Avatar URL.
 	var avatar_url : String setget , _get_avatar_url
 	var _avatar_url = null
 	func _get_avatar_url() -> String:
 		return "" if not _avatar_url is String else String(_avatar_url)
 
-	### <summary>
-	### Description string.
-	### </summary>
+	# Description string.
 	var description : String setget , _get_description
 	var _description = null
 	func _get_description() -> String:
 		return "" if not _description is String else String(_description)
 
-	### <summary>
-	### The ID of the group to update.
-	### </summary>
+	# The ID of the group to update.
 	var group_id : String setget , _get_group_id
 	var _group_id = null
 	func _get_group_id() -> String:
 		return "" if not _group_id is String else String(_group_id)
 
-	### <summary>
-	### Lang tag.
-	### </summary>
+	# Lang tag.
 	var lang_tag : String setget , _get_lang_tag
 	var _lang_tag = null
 	func _get_lang_tag() -> String:
 		return "" if not _lang_tag is String else String(_lang_tag)
 
-	### <summary>
-	### Name.
-	### </summary>
+	# Name.
 	var name : String setget , _get_name
 	var _name = null
 	func _get_name() -> String:
 		return "" if not _name is String else String(_name)
 
-	### <summary>
-	### Open is true if anyone should be allowed to join, or false if joins must be approved by a group admin.
-	### </summary>
+	# Open is true if anyone should be allowed to join, or false if joins must be approved by a group admin.
 	var open : bool setget , _get_open
 	var _open = null
 	func _get_open() -> bool:
@@ -2794,9 +2395,7 @@ class ApiUpdateGroupRequest extends NakamaAsyncResult:
 		output += "open: %s, " % _open
 		return output
 
-### <summary>
-### A user in the server.
-### </summary>
+# A user in the server.
 class ApiUser extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -2805,6 +2404,7 @@ class ApiUser extends NakamaAsyncResult:
 		"display_name": {"name": "_display_name", "type": TYPE_STRING, "required": false},
 		"edge_count": {"name": "_edge_count", "type": TYPE_INT, "required": false},
 		"facebook_id": {"name": "_facebook_id", "type": TYPE_STRING, "required": false},
+		"facebook_instant_game_id": {"name": "_facebook_instant_game_id", "type": TYPE_STRING, "required": false},
 		"gamecenter_id": {"name": "_gamecenter_id", "type": TYPE_STRING, "required": false},
 		"google_id": {"name": "_google_id", "type": TYPE_STRING, "required": false},
 		"id": {"name": "_id", "type": TYPE_STRING, "required": false},
@@ -2818,129 +2418,103 @@ class ApiUser extends NakamaAsyncResult:
 		"username": {"name": "_username", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### A URL for an avatar image.
-	### </summary>
+	# A URL for an avatar image.
 	var avatar_url : String setget , _get_avatar_url
 	var _avatar_url = null
 	func _get_avatar_url() -> String:
 		return "" if not _avatar_url is String else String(_avatar_url)
 
-	### <summary>
-	### The UNIX time when the user was created.
-	### </summary>
+	# The UNIX time when the user was created.
 	var create_time : String setget , _get_create_time
 	var _create_time = null
 	func _get_create_time() -> String:
 		return "" if not _create_time is String else String(_create_time)
 
-	### <summary>
-	### The display name of the user.
-	### </summary>
+	# The display name of the user.
 	var display_name : String setget , _get_display_name
 	var _display_name = null
 	func _get_display_name() -> String:
 		return "" if not _display_name is String else String(_display_name)
 
-	### <summary>
-	### Number of related edges to this user.
-	### </summary>
+	# Number of related edges to this user.
 	var edge_count : int setget , _get_edge_count
 	var _edge_count = null
 	func _get_edge_count() -> int:
 		return 0 if not _edge_count is int else int(_edge_count)
 
-	### <summary>
-	### The Facebook id in the user's account.
-	### </summary>
+	# The Facebook id in the user's account.
 	var facebook_id : String setget , _get_facebook_id
 	var _facebook_id = null
 	func _get_facebook_id() -> String:
 		return "" if not _facebook_id is String else String(_facebook_id)
 
-	### <summary>
-	### The Apple Game Center in of the user's account.
-	### </summary>
+	# The Facebook Instant Game id in the user's account.
+	var facebook_instant_game_id : String setget , _get_facebook_instant_game_id
+	var _facebook_instant_game_id = null
+	func _get_facebook_instant_game_id() -> String:
+		return "" if not _facebook_instant_game_id is String else String(_facebook_instant_game_id)
+
+	# The Apple Game Center in of the user's account.
 	var gamecenter_id : String setget , _get_gamecenter_id
 	var _gamecenter_id = null
 	func _get_gamecenter_id() -> String:
 		return "" if not _gamecenter_id is String else String(_gamecenter_id)
 
-	### <summary>
-	### The Google id in the user's account.
-	### </summary>
+	# The Google id in the user's account.
 	var google_id : String setget , _get_google_id
 	var _google_id = null
 	func _get_google_id() -> String:
 		return "" if not _google_id is String else String(_google_id)
 
-	### <summary>
-	### The id of the user's account.
-	### </summary>
+	# The id of the user's account.
 	var id : String setget , _get_id
 	var _id = null
 	func _get_id() -> String:
 		return "" if not _id is String else String(_id)
 
-	### <summary>
-	### The language expected to be a tag which follows the BCP-47 spec.
-	### </summary>
+	# The language expected to be a tag which follows the BCP-47 spec.
 	var lang_tag : String setget , _get_lang_tag
 	var _lang_tag = null
 	func _get_lang_tag() -> String:
 		return "" if not _lang_tag is String else String(_lang_tag)
 
-	### <summary>
-	### The location set by the user.
-	### </summary>
+	# The location set by the user.
 	var location : String setget , _get_location
 	var _location = null
 	func _get_location() -> String:
 		return "" if not _location is String else String(_location)
 
-	### <summary>
-	### Additional information stored as a JSON object.
-	### </summary>
+	# Additional information stored as a JSON object.
 	var metadata : String setget , _get_metadata
 	var _metadata = null
 	func _get_metadata() -> String:
 		return "" if not _metadata is String else String(_metadata)
 
-	### <summary>
-	### Indicates whether the user is currently online.
-	### </summary>
+	# Indicates whether the user is currently online.
 	var online : bool setget , _get_online
 	var _online = null
 	func _get_online() -> bool:
 		return false if not _online is bool else bool(_online)
 
-	### <summary>
-	### The Steam id in the user's account.
-	### </summary>
+	# The Steam id in the user's account.
 	var steam_id : String setget , _get_steam_id
 	var _steam_id = null
 	func _get_steam_id() -> String:
 		return "" if not _steam_id is String else String(_steam_id)
 
-	### <summary>
-	### The timezone set by the user.
-	### </summary>
+	# The timezone set by the user.
 	var timezone : String setget , _get_timezone
 	var _timezone = null
 	func _get_timezone() -> String:
 		return "" if not _timezone is String else String(_timezone)
 
-	### <summary>
-	### The UNIX time when the user was last updated.
-	### </summary>
+	# The UNIX time when the user was last updated.
 	var update_time : String setget , _get_update_time
 	var _update_time = null
 	func _get_update_time() -> String:
 		return "" if not _update_time is String else String(_update_time)
 
-	### <summary>
-	### The username of the user's account.
-	### </summary>
+	# The username of the user's account.
 	var username : String setget , _get_username
 	var _username = null
 	func _get_username() -> String:
@@ -2964,6 +2538,7 @@ class ApiUser extends NakamaAsyncResult:
 		output += "display_name: %s, " % _display_name
 		output += "edge_count: %s, " % _edge_count
 		output += "facebook_id: %s, " % _facebook_id
+		output += "facebook_instant_game_id: %s, " % _facebook_instant_game_id
 		output += "gamecenter_id: %s, " % _gamecenter_id
 		output += "google_id: %s, " % _google_id
 		output += "id: %s, " % _id
@@ -2977,9 +2552,7 @@ class ApiUser extends NakamaAsyncResult:
 		output += "username: %s, " % _username
 		return output
 
-### <summary>
-### A list of groups belonging to a user, along with the user's role in each group.
-### </summary>
+# A list of groups belonging to a user, along with the user's role in each group.
 class ApiUserGroupList extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -2987,17 +2560,13 @@ class ApiUserGroupList extends NakamaAsyncResult:
 		"user_groups": {"name": "_user_groups", "type": TYPE_ARRAY, "required": false, "content": "UserGroupListUserGroup"},
 	}
 
-	### <summary>
-	### Cursor for the next page of results, if any.
-	### </summary>
+	# Cursor for the next page of results, if any.
 	var cursor : String setget , _get_cursor
 	var _cursor = null
 	func _get_cursor() -> String:
 		return "" if not _cursor is String else String(_cursor)
 
-	### <summary>
-	### Group-role pairs for a user.
-	### </summary>
+	# Group-role pairs for a user.
 	var user_groups : Array setget , _get_user_groups
 	var _user_groups = null
 	func _get_user_groups() -> Array:
@@ -3020,18 +2589,14 @@ class ApiUserGroupList extends NakamaAsyncResult:
 		output += "user_groups: %s, " % [_user_groups]
 		return output
 
-### <summary>
-### A collection of zero or more users.
-### </summary>
+# A collection of zero or more users.
 class ApiUsers extends NakamaAsyncResult:
 
 	const _SCHEMA = {
 		"users": {"name": "_users", "type": TYPE_ARRAY, "required": false, "content": "ApiUser"},
 	}
 
-	### <summary>
-	### The User objects.
-	### </summary>
+	# The User objects.
 	var users : Array setget , _get_users
 	var _users = null
 	func _get_users() -> Array:
@@ -3053,9 +2618,7 @@ class ApiUsers extends NakamaAsyncResult:
 		output += "users: %s, " % [_users]
 		return output
 
-### <summary>
-### The object to store.
-### </summary>
+# The object to store.
 class ApiWriteStorageObject extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -3067,49 +2630,37 @@ class ApiWriteStorageObject extends NakamaAsyncResult:
 		"version": {"name": "_version", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### The collection to store the object.
-	### </summary>
+	# The collection to store the object.
 	var collection : String setget , _get_collection
 	var _collection = null
 	func _get_collection() -> String:
 		return "" if not _collection is String else String(_collection)
 
-	### <summary>
-	### The key for the object within the collection.
-	### </summary>
+	# The key for the object within the collection.
 	var key : String setget , _get_key
 	var _key = null
 	func _get_key() -> String:
 		return "" if not _key is String else String(_key)
 
-	### <summary>
-	### The read access permissions for the object.
-	### </summary>
+	# The read access permissions for the object.
 	var permission_read : int setget , _get_permission_read
 	var _permission_read = null
 	func _get_permission_read() -> int:
 		return 0 if not _permission_read is int else int(_permission_read)
 
-	### <summary>
-	### The write access permissions for the object.
-	### </summary>
+	# The write access permissions for the object.
 	var permission_write : int setget , _get_permission_write
 	var _permission_write = null
 	func _get_permission_write() -> int:
 		return 0 if not _permission_write is int else int(_permission_write)
 
-	### <summary>
-	### The value of the object.
-	### </summary>
+	# The value of the object.
 	var value : String setget , _get_value
 	var _value = null
 	func _get_value() -> String:
 		return "" if not _value is String else String(_value)
 
-	### <summary>
-	### The version hash of the object to check. Possible values are: ["", "*", "#hash#"].
-	### </summary>
+	# The version hash of the object to check. Possible values are: ["", "*", "#hash#"].
 	var version : String setget , _get_version
 	var _version = null
 	func _get_version() -> String:
@@ -3136,18 +2687,14 @@ class ApiWriteStorageObject extends NakamaAsyncResult:
 		output += "version: %s, " % _version
 		return output
 
-### <summary>
-### Write objects to the storage engine.
-### </summary>
+# Write objects to the storage engine.
 class ApiWriteStorageObjectsRequest extends NakamaAsyncResult:
 
 	const _SCHEMA = {
 		"objects": {"name": "_objects", "type": TYPE_ARRAY, "required": false, "content": "ApiWriteStorageObject"},
 	}
 
-	### <summary>
-	### The objects to store on the server.
-	### </summary>
+	# The objects to store on the server.
 	var objects : Array setget , _get_objects
 	var _objects = null
 	func _get_objects() -> Array:
@@ -3169,9 +2716,7 @@ class ApiWriteStorageObjectsRequest extends NakamaAsyncResult:
 		output += "objects: %s, " % [_objects]
 		return output
 
-### <summary>
-### The low level client for the Nakama API.
-### </summary>
+# The low level client for the Nakama API.
 class ApiClient extends Reference:
 
 	var _base_uri : String
@@ -3186,9 +2731,7 @@ class ApiClient extends Reference:
 		_http_adapter = p_http_adapter
 		_namespace = p_namespace
 
-	### <summary>
-	### A healthcheck which load balancers can use to check the service.
-	### </summary>
+	# A healthcheck which load balancers can use to check the service.
 	func healthcheck_async(
 		p_bearer_token : String
 	) -> NakamaAsyncResult:
@@ -3206,9 +2749,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Fetch the current user's account.
-	### </summary>
+	# Fetch the current user's account.
 	func get_account_async(
 		p_bearer_token : String
 	) -> ApiAccount:
@@ -3227,9 +2768,7 @@ class ApiClient extends Reference:
 		var out : ApiAccount = NakamaSerializer.deserialize(_namespace, "ApiAccount", result)
 		return out
 
-	### <summary>
-	### Update fields in the current user's account.
-	### </summary>
+	# Update fields in the current user's account.
 	func update_account_async(
 		p_bearer_token : String
 		, p_body : ApiUpdateAccountRequest
@@ -3249,9 +2788,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Authenticate a user with a custom id against the server.
-	### </summary>
+	# Authenticate a user with a custom id against the server.
 	func authenticate_custom_async(
 		p_basic_auth_username : String
 		, p_basic_auth_password : String
@@ -3280,9 +2817,7 @@ class ApiClient extends Reference:
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
 		return out
 
-	### <summary>
-	### Authenticate a user with a device id against the server.
-	### </summary>
+	# Authenticate a user with a device id against the server.
 	func authenticate_device_async(
 		p_basic_auth_username : String
 		, p_basic_auth_password : String
@@ -3311,9 +2846,7 @@ class ApiClient extends Reference:
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
 		return out
 
-	### <summary>
-	### Authenticate a user with an email+password against the server.
-	### </summary>
+	# Authenticate a user with an email+password against the server.
 	func authenticate_email_async(
 		p_basic_auth_username : String
 		, p_basic_auth_password : String
@@ -3342,9 +2875,7 @@ class ApiClient extends Reference:
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
 		return out
 
-	### <summary>
-	### Authenticate a user with a Facebook OAuth token against the server.
-	### </summary>
+	# Authenticate a user with a Facebook OAuth token against the server.
 	func authenticate_facebook_async(
 		p_basic_auth_username : String
 		, p_basic_auth_password : String
@@ -3376,9 +2907,36 @@ class ApiClient extends Reference:
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
 		return out
 
-	### <summary>
-	### Authenticate a user with Apple's GameCenter against the server.
-	### </summary>
+	# Authenticate a user with a Facebook Instant Game token against the server.
+	func authenticate_facebook_instant_game_async(
+		p_basic_auth_username : String
+		, p_basic_auth_password : String
+		, p_body : ApiAccountFacebookInstantGame
+		, p_create = null # : boolean
+		, p_username = null # : string
+	) -> ApiSession:
+		var urlpath : String = "/v2/account/authenticate/facebookinstantgame"
+		var query_params = ""
+		if p_create != null:
+			query_params += "create=%s&" % str(bool(p_create)).to_lower()
+		if p_username != null:
+			query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
+		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
+		var method = "POST"
+		var headers = {}
+		var credentials = Marshalls.utf8_to_base64(p_basic_auth_username + ":" + p_basic_auth_password)
+		var header = "Basic %s" % credentials
+		headers["Authorization"] = header
+
+		var content : PoolByteArray
+		content = JSON.print(p_body.serialize()).to_utf8()
+		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		if result is NakamaException:
+			return ApiSession.new(result)
+		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
+		return out
+
+	# Authenticate a user with Apple's GameCenter against the server.
 	func authenticate_game_center_async(
 		p_basic_auth_username : String
 		, p_basic_auth_password : String
@@ -3407,9 +2965,7 @@ class ApiClient extends Reference:
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
 		return out
 
-	### <summary>
-	### Authenticate a user with Google against the server.
-	### </summary>
+	# Authenticate a user with Google against the server.
 	func authenticate_google_async(
 		p_basic_auth_username : String
 		, p_basic_auth_password : String
@@ -3438,9 +2994,7 @@ class ApiClient extends Reference:
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
 		return out
 
-	### <summary>
-	### Authenticate a user with Steam against the server.
-	### </summary>
+	# Authenticate a user with Steam against the server.
 	func authenticate_steam_async(
 		p_basic_auth_username : String
 		, p_basic_auth_password : String
@@ -3469,9 +3023,7 @@ class ApiClient extends Reference:
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
 		return out
 
-	### <summary>
-	### Add a custom ID to the social profiles on the current user's account.
-	### </summary>
+	# Add a custom ID to the social profiles on the current user's account.
 	func link_custom_async(
 		p_bearer_token : String
 		, p_body : ApiAccountCustom
@@ -3491,9 +3043,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Add a device ID to the social profiles on the current user's account.
-	### </summary>
+	# Add a device ID to the social profiles on the current user's account.
 	func link_device_async(
 		p_bearer_token : String
 		, p_body : ApiAccountDevice
@@ -3513,9 +3063,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Add an email+password to the social profiles on the current user's account.
-	### </summary>
+	# Add an email+password to the social profiles on the current user's account.
 	func link_email_async(
 		p_bearer_token : String
 		, p_body : ApiAccountEmail
@@ -3535,9 +3083,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Add Facebook to the social profiles on the current user's account.
-	### </summary>
+	# Add Facebook to the social profiles on the current user's account.
 	func link_facebook_async(
 		p_bearer_token : String
 		, p_body : ApiAccountFacebook
@@ -3560,9 +3106,27 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Add Apple's GameCenter to the social profiles on the current user's account.
-	### </summary>
+	# Add Facebook Instant Game to the social profiles on the current user's account.
+	func link_facebook_instant_game_async(
+		p_bearer_token : String
+		, p_body : ApiAccountFacebookInstantGame
+	) -> NakamaAsyncResult:
+		var urlpath : String = "/v2/account/link/facebookinstantgame"
+		var query_params = ""
+		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
+		var method = "POST"
+		var headers = {}
+		var header = "Bearer %s" % p_bearer_token
+		headers["Authorization"] = header
+
+		var content : PoolByteArray
+		content = JSON.print(p_body.serialize()).to_utf8()
+		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		if result is NakamaException:
+			return NakamaAsyncResult.new(result)
+		return NakamaAsyncResult.new()
+
+	# Add Apple's GameCenter to the social profiles on the current user's account.
 	func link_game_center_async(
 		p_bearer_token : String
 		, p_body : ApiAccountGameCenter
@@ -3582,9 +3146,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Add Google to the social profiles on the current user's account.
-	### </summary>
+	# Add Google to the social profiles on the current user's account.
 	func link_google_async(
 		p_bearer_token : String
 		, p_body : ApiAccountGoogle
@@ -3604,9 +3166,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Add Steam to the social profiles on the current user's account.
-	### </summary>
+	# Add Steam to the social profiles on the current user's account.
 	func link_steam_async(
 		p_bearer_token : String
 		, p_body : ApiAccountSteam
@@ -3626,9 +3186,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Remove the custom ID from the social profiles on the current user's account.
-	### </summary>
+	# Remove the custom ID from the social profiles on the current user's account.
 	func unlink_custom_async(
 		p_bearer_token : String
 		, p_body : ApiAccountCustom
@@ -3648,9 +3206,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Remove the device ID from the social profiles on the current user's account.
-	### </summary>
+	# Remove the device ID from the social profiles on the current user's account.
 	func unlink_device_async(
 		p_bearer_token : String
 		, p_body : ApiAccountDevice
@@ -3670,9 +3226,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Remove the email+password from the social profiles on the current user's account.
-	### </summary>
+	# Remove the email+password from the social profiles on the current user's account.
 	func unlink_email_async(
 		p_bearer_token : String
 		, p_body : ApiAccountEmail
@@ -3692,9 +3246,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Remove Facebook from the social profiles on the current user's account.
-	### </summary>
+	# Remove Facebook from the social profiles on the current user's account.
 	func unlink_facebook_async(
 		p_bearer_token : String
 		, p_body : ApiAccountFacebook
@@ -3714,9 +3266,27 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Remove Apple's GameCenter from the social profiles on the current user's account.
-	### </summary>
+	# Remove Facebook Instant Game profile from the social profiles on the current user's account.
+	func unlink_facebook_instant_game_async(
+		p_bearer_token : String
+		, p_body : ApiAccountFacebookInstantGame
+	) -> NakamaAsyncResult:
+		var urlpath : String = "/v2/account/unlink/facebookinstantgame"
+		var query_params = ""
+		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
+		var method = "POST"
+		var headers = {}
+		var header = "Bearer %s" % p_bearer_token
+		headers["Authorization"] = header
+
+		var content : PoolByteArray
+		content = JSON.print(p_body.serialize()).to_utf8()
+		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		if result is NakamaException:
+			return NakamaAsyncResult.new(result)
+		return NakamaAsyncResult.new()
+
+	# Remove Apple's GameCenter from the social profiles on the current user's account.
 	func unlink_game_center_async(
 		p_bearer_token : String
 		, p_body : ApiAccountGameCenter
@@ -3736,9 +3306,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Remove Google from the social profiles on the current user's account.
-	### </summary>
+	# Remove Google from the social profiles on the current user's account.
 	func unlink_google_async(
 		p_bearer_token : String
 		, p_body : ApiAccountGoogle
@@ -3758,9 +3326,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Remove Steam from the social profiles on the current user's account.
-	### </summary>
+	# Remove Steam from the social profiles on the current user's account.
 	func unlink_steam_async(
 		p_bearer_token : String
 		, p_body : ApiAccountSteam
@@ -3780,9 +3346,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### List a channel's message history.
-	### </summary>
+	# List a channel's message history.
 	func list_channel_messages_async(
 		p_bearer_token : String
 		, p_channel_id : String
@@ -3812,9 +3376,7 @@ class ApiClient extends Reference:
 		var out : ApiChannelMessageList = NakamaSerializer.deserialize(_namespace, "ApiChannelMessageList", result)
 		return out
 
-	### <summary>
-	### Submit an event for processing in the server's registered runtime custom events handler.
-	### </summary>
+	# Submit an event for processing in the server's registered runtime custom events handler.
 	func event_async(
 		p_bearer_token : String
 		, p_body : ApiEvent
@@ -3834,9 +3396,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Delete one or more users by ID or username.
-	### </summary>
+	# Delete one or more users by ID or username.
 	func delete_friends_async(
 		p_bearer_token : String
 		, p_ids = null # : array
@@ -3862,9 +3422,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### List all friends for the current user.
-	### </summary>
+	# List all friends for the current user.
 	func list_friends_async(
 		p_bearer_token : String
 		, p_limit = null # : integer
@@ -3892,9 +3450,7 @@ class ApiClient extends Reference:
 		var out : ApiFriendList = NakamaSerializer.deserialize(_namespace, "ApiFriendList", result)
 		return out
 
-	### <summary>
-	### Add friends by ID or username to a user's account.
-	### </summary>
+	# Add friends by ID or username to a user's account.
 	func add_friends_async(
 		p_bearer_token : String
 		, p_ids = null # : array
@@ -3920,9 +3476,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Block one or more users by ID or username.
-	### </summary>
+	# Block one or more users by ID or username.
 	func block_friends_async(
 		p_bearer_token : String
 		, p_ids = null # : array
@@ -3948,9 +3502,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Import Facebook friends and add them to a user's account.
-	### </summary>
+	# Import Facebook friends and add them to a user's account.
 	func import_facebook_friends_async(
 		p_bearer_token : String
 		, p_body : ApiAccountFacebook
@@ -3973,9 +3525,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### List groups based on given filters.
-	### </summary>
+	# List groups based on given filters.
 	func list_groups_async(
 		p_bearer_token : String
 		, p_name = null # : string
@@ -4003,9 +3553,7 @@ class ApiClient extends Reference:
 		var out : ApiGroupList = NakamaSerializer.deserialize(_namespace, "ApiGroupList", result)
 		return out
 
-	### <summary>
-	### Create a new group with the current user as the owner.
-	### </summary>
+	# Create a new group with the current user as the owner.
 	func create_group_async(
 		p_bearer_token : String
 		, p_body : ApiCreateGroupRequest
@@ -4026,9 +3574,7 @@ class ApiClient extends Reference:
 		var out : ApiGroup = NakamaSerializer.deserialize(_namespace, "ApiGroup", result)
 		return out
 
-	### <summary>
-	### Delete a group by ID.
-	### </summary>
+	# Delete a group by ID.
 	func delete_group_async(
 		p_bearer_token : String
 		, p_group_id : String
@@ -4048,9 +3594,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Update fields in a given group.
-	### </summary>
+	# Update fields in a given group.
 	func update_group_async(
 		p_bearer_token : String
 		, p_group_id : String
@@ -4072,9 +3616,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Add users to a group.
-	### </summary>
+	# Add users to a group.
 	func add_group_users_async(
 		p_bearer_token : String
 		, p_group_id : String
@@ -4098,9 +3640,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Ban a set of users from a group.
-	### </summary>
+	# Ban a set of users from a group.
 	func ban_group_users_async(
 		p_bearer_token : String
 		, p_group_id : String
@@ -4124,9 +3664,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Immediately join an open group, or request to join a closed one.
-	### </summary>
+	# Immediately join an open group, or request to join a closed one.
 	func join_group_async(
 		p_bearer_token : String
 		, p_group_id : String
@@ -4146,9 +3684,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Kick a set of users from a group.
-	### </summary>
+	# Kick a set of users from a group.
 	func kick_group_users_async(
 		p_bearer_token : String
 		, p_group_id : String
@@ -4172,9 +3708,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Leave a group the user is a member of.
-	### </summary>
+	# Leave a group the user is a member of.
 	func leave_group_async(
 		p_bearer_token : String
 		, p_group_id : String
@@ -4194,9 +3728,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Promote a set of users in a group to the next role up.
-	### </summary>
+	# Promote a set of users in a group to the next role up.
 	func promote_group_users_async(
 		p_bearer_token : String
 		, p_group_id : String
@@ -4220,9 +3752,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### List all users that are part of a group.
-	### </summary>
+	# List all users that are part of a group.
 	func list_group_users_async(
 		p_bearer_token : String
 		, p_group_id : String
@@ -4252,9 +3782,7 @@ class ApiClient extends Reference:
 		var out : ApiGroupUserList = NakamaSerializer.deserialize(_namespace, "ApiGroupUserList", result)
 		return out
 
-	### <summary>
-	### Delete a leaderboard record.
-	### </summary>
+	# Delete a leaderboard record.
 	func delete_leaderboard_record_async(
 		p_bearer_token : String
 		, p_leaderboard_id : String
@@ -4274,9 +3802,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### List leaderboard records.
-	### </summary>
+	# List leaderboard records.
 	func list_leaderboard_records_async(
 		p_bearer_token : String
 		, p_leaderboard_id : String
@@ -4310,9 +3836,7 @@ class ApiClient extends Reference:
 		var out : ApiLeaderboardRecordList = NakamaSerializer.deserialize(_namespace, "ApiLeaderboardRecordList", result)
 		return out
 
-	### <summary>
-	### Write a record to a leaderboard.
-	### </summary>
+	# Write a record to a leaderboard.
 	func write_leaderboard_record_async(
 		p_bearer_token : String
 		, p_leaderboard_id : String
@@ -4335,9 +3859,7 @@ class ApiClient extends Reference:
 		var out : ApiLeaderboardRecord = NakamaSerializer.deserialize(_namespace, "ApiLeaderboardRecord", result)
 		return out
 
-	### <summary>
-	### List leaderboard records that belong to a user.
-	### </summary>
+	# List leaderboard records that belong to a user.
 	func list_leaderboard_records_around_owner_async(
 		p_bearer_token : String
 		, p_leaderboard_id : String
@@ -4366,9 +3888,7 @@ class ApiClient extends Reference:
 		var out : ApiLeaderboardRecordList = NakamaSerializer.deserialize(_namespace, "ApiLeaderboardRecordList", result)
 		return out
 
-	### <summary>
-	### Fetch list of running matches.
-	### </summary>
+	# Fetch list of running matches.
 	func list_matches_async(
 		p_bearer_token : String
 		, p_limit = null # : integer
@@ -4405,9 +3925,7 @@ class ApiClient extends Reference:
 		var out : ApiMatchList = NakamaSerializer.deserialize(_namespace, "ApiMatchList", result)
 		return out
 
-	### <summary>
-	### Delete one or more notifications for the current user.
-	### </summary>
+	# Delete one or more notifications for the current user.
 	func delete_notifications_async(
 		p_bearer_token : String
 		, p_ids = null # : array
@@ -4429,9 +3947,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### Fetch list of notifications.
-	### </summary>
+	# Fetch list of notifications.
 	func list_notifications_async(
 		p_bearer_token : String
 		, p_limit = null # : integer
@@ -4456,9 +3972,7 @@ class ApiClient extends Reference:
 		var out : ApiNotificationList = NakamaSerializer.deserialize(_namespace, "ApiNotificationList", result)
 		return out
 
-	### <summary>
-	### Execute a Lua function on the server.
-	### </summary>
+	# Execute a Lua function on the server.
 	func rpc_func2_async(
 		p_bearer_token : String
 		, p_id : String
@@ -4486,9 +4000,7 @@ class ApiClient extends Reference:
 		var out : ApiRpc = NakamaSerializer.deserialize(_namespace, "ApiRpc", result)
 		return out
 
-	### <summary>
-	### Execute a Lua function on the server.
-	### </summary>
+	# Execute a Lua function on the server.
 	func rpc_func_async(
 		p_bearer_token : String
 		, p_id : String
@@ -4512,9 +4024,7 @@ class ApiClient extends Reference:
 		var out : ApiRpc = NakamaSerializer.deserialize(_namespace, "ApiRpc", result)
 		return out
 
-	### <summary>
-	### Get storage objects.
-	### </summary>
+	# Get storage objects.
 	func read_storage_objects_async(
 		p_bearer_token : String
 		, p_body : ApiReadStorageObjectsRequest
@@ -4535,9 +4045,7 @@ class ApiClient extends Reference:
 		var out : ApiStorageObjects = NakamaSerializer.deserialize(_namespace, "ApiStorageObjects", result)
 		return out
 
-	### <summary>
-	### Write objects into the storage engine.
-	### </summary>
+	# Write objects into the storage engine.
 	func write_storage_objects_async(
 		p_bearer_token : String
 		, p_body : ApiWriteStorageObjectsRequest
@@ -4558,9 +4066,7 @@ class ApiClient extends Reference:
 		var out : ApiStorageObjectAcks = NakamaSerializer.deserialize(_namespace, "ApiStorageObjectAcks", result)
 		return out
 
-	### <summary>
-	### Delete one or more objects by ID or username.
-	### </summary>
+	# Delete one or more objects by ID or username.
 	func delete_storage_objects_async(
 		p_bearer_token : String
 		, p_body : ApiDeleteStorageObjectsRequest
@@ -4580,9 +4086,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### List publicly readable storage objects in a given collection.
-	### </summary>
+	# List publicly readable storage objects in a given collection.
 	func list_storage_objects_async(
 		p_bearer_token : String
 		, p_collection : String
@@ -4612,9 +4116,7 @@ class ApiClient extends Reference:
 		var out : ApiStorageObjectList = NakamaSerializer.deserialize(_namespace, "ApiStorageObjectList", result)
 		return out
 
-	### <summary>
-	### List publicly readable storage objects in a given collection.
-	### </summary>
+	# List publicly readable storage objects in a given collection.
 	func list_storage_objects2_async(
 		p_bearer_token : String
 		, p_collection : String
@@ -4643,9 +4145,7 @@ class ApiClient extends Reference:
 		var out : ApiStorageObjectList = NakamaSerializer.deserialize(_namespace, "ApiStorageObjectList", result)
 		return out
 
-	### <summary>
-	### List current or upcoming tournaments.
-	### </summary>
+	# List current or upcoming tournaments.
 	func list_tournaments_async(
 		p_bearer_token : String
 		, p_category_start = null # : integer
@@ -4682,9 +4182,7 @@ class ApiClient extends Reference:
 		var out : ApiTournamentList = NakamaSerializer.deserialize(_namespace, "ApiTournamentList", result)
 		return out
 
-	### <summary>
-	### List tournament records.
-	### </summary>
+	# List tournament records.
 	func list_tournament_records_async(
 		p_bearer_token : String
 		, p_tournament_id : String
@@ -4718,9 +4216,7 @@ class ApiClient extends Reference:
 		var out : ApiTournamentRecordList = NakamaSerializer.deserialize(_namespace, "ApiTournamentRecordList", result)
 		return out
 
-	### <summary>
-	### Write a record to a tournament.
-	### </summary>
+	# Write a record to a tournament.
 	func write_tournament_record_async(
 		p_bearer_token : String
 		, p_tournament_id : String
@@ -4743,9 +4239,7 @@ class ApiClient extends Reference:
 		var out : ApiLeaderboardRecord = NakamaSerializer.deserialize(_namespace, "ApiLeaderboardRecord", result)
 		return out
 
-	### <summary>
-	### Attempt to join an open and running tournament.
-	### </summary>
+	# Attempt to join an open and running tournament.
 	func join_tournament_async(
 		p_bearer_token : String
 		, p_tournament_id : String
@@ -4765,9 +4259,7 @@ class ApiClient extends Reference:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
 
-	### <summary>
-	### List tournament records for a given owner.
-	### </summary>
+	# List tournament records for a given owner.
 	func list_tournament_records_around_owner_async(
 		p_bearer_token : String
 		, p_tournament_id : String
@@ -4796,9 +4288,7 @@ class ApiClient extends Reference:
 		var out : ApiTournamentRecordList = NakamaSerializer.deserialize(_namespace, "ApiTournamentRecordList", result)
 		return out
 
-	### <summary>
-	### Fetch zero or more users by ID and/or username.
-	### </summary>
+	# Fetch zero or more users by ID and/or username.
 	func get_users_async(
 		p_bearer_token : String
 		, p_ids = null # : array
@@ -4829,9 +4319,7 @@ class ApiClient extends Reference:
 		var out : ApiUsers = NakamaSerializer.deserialize(_namespace, "ApiUsers", result)
 		return out
 
-	### <summary>
-	### List groups the current user belongs to.
-	### </summary>
+	# List groups the current user belongs to.
 	func list_user_groups_async(
 		p_bearer_token : String
 		, p_user_id : String

--- a/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
@@ -2,9 +2,7 @@ extends NakamaAsyncResult
 
 class_name NakamaRTAPI
 
-### <summary>
-### A chat channel on the server.
-### </summary>
+# A chat channel on the server.
 class Channel extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -17,39 +15,25 @@ class Channel extends NakamaAsyncResult:
 		"user_id_two": {"name": "user_id_two", "type": TYPE_STRING, "required": false}
 	}
 
-	### <summary>
-	### The server-assigned channel ID.
-	### </summary>
+	# The server-assigned channel ID.
 	var id : String
 
-	### <summary>
-	### The presences visible on the chat channel.
-	### </summary>
+	# The presences visible on the chat channel.
 	var presences : Array # of objects NakamaUserPresence
 
-	### <summary>
-	### The presence of the current user. i.e. Your self.
-	### </summary>
+	# The presence of the current user. i.e. Your self.
 	var self_presence : NakamaRTAPI.UserPresence
 
-	### <summary>
-	### The name of the chat room, or an empty string if this message was not sent through a chat room.
-	### </summary>
+	# The name of the chat room, or an empty string if this message was not sent through a chat room.
 	var room_name : String
 
-	### <summary>
-	### The ID of the group, or an empty string if this message was not sent through a group channel.
-	### </summary>
+	# The ID of the group, or an empty string if this message was not sent through a group channel.
 	var group_id : String
 
-	### <summary>
-	### The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
-	### </summary>
+	# The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
 	var user_id_one : String
 
-	### <summary>
-	### The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
-	### </summary>
+	# The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
 	var user_id_two : String
 
 	func _init(p_ex = null).(p_ex):
@@ -84,59 +68,37 @@ class ChannelMessageAck extends NakamaAsyncResult:
 		"user_id_two": {"name": "user_id_two", "type": TYPE_STRING, "required": false}
 	}
 
-	### <summary>
-	### The server-assigned channel ID.
-	### </summary>
+	# The server-assigned channel ID.
 	var channel_id : String
 
-	### <summary>
-	### A user-defined code for the chat message.
-	### </summary>
+	# A user-defined code for the chat message.
 	var code : int
 
-	### <summary>
-	### The UNIX time when the message was created.
-	### </summary>
+	# The UNIX time when the message was created.
 	var create_time : String
 
-	### <summary>
-	### A unique ID for the chat message.
-	### </summary>
+	# A unique ID for the chat message.
 	var message_id : String
 
-	### <summary>
-	### True if the chat message has been stored in history.
-	### </summary>
+	# True if the chat message has been stored in history.
 	var persistent : bool
 
-	### <summary>
-	### The UNIX time when the message was updated.
-	### </summary>
+	# The UNIX time when the message was updated.
 	var update_time : String
 
-	### <summary>
-	### The username of the sender of the message.
-	### </summary>
+	# The username of the sender of the message.
 	var username : String
 
-	### <summary>
-	### The name of the chat room, or an empty string if this message was not sent through a chat room.
-	### </summary>
+	# The name of the chat room, or an empty string if this message was not sent through a chat room.
 	var room_name : String
 
-	### <summary>
-	### The ID of the group, or an empty string if this message was not sent through a group channel.
-	### </summary>
+	# The ID of the group, or an empty string if this message was not sent through a group channel.
 	var group_id : String
 
-	### <summary>
-	### The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
-	### </summary>
+	# The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
 	var user_id_one : String
 
-	### <summary>
-	### The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
-	### </summary>
+	# The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
 	var user_id_two : String
 
 	func _init(p_ex = null).(p_ex):
@@ -155,9 +117,7 @@ class ChannelMessageAck extends NakamaAsyncResult:
 		return "channel_message_ack"
 
 
-### <summary>
-### A batch of join and leave presences on a chat channel.
-### </summary>
+# A batch of join and leave presences on a chat channel.
 class ChannelPresenceEvent extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -170,39 +130,25 @@ class ChannelPresenceEvent extends NakamaAsyncResult:
 		"user_id_two": {"name": "user_id_two", "type": TYPE_STRING, "required": false}
 	}
 
-	### <summary>
-	### The unique identifier of the chat channel.
-	### </summary>
+	# The unique identifier of the chat channel.
 	var channel_id : String
 
-	### <summary>
-	### Presences of the users who joined the channel.
-	### </summary>
+	# Presences of the users who joined the channel.
 	var joins : Array # UserPresence
 
-	### <summary>
-	### Presences of users who left the channel.
-	### </summary>
+	# Presences of users who left the channel.
 	var leaves : Array # UserPresence
 
-	### <summary>
-	### The name of the chat room, or an empty string if this message was not sent through a chat room.
-	### </summary>
+	# The name of the chat room, or an empty string if this message was not sent through a chat room.
 	var room_name : String
 
-	### <summary>
-	### The ID of the group, or an empty string if this message was not sent through a group channel.
-	### </summary>
+	# The ID of the group, or an empty string if this message was not sent through a group channel.
 	var group_id : String
 
-	### <summary>
-	### The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
-	### </summary>
+	# The ID of the first DM user, or an empty string if this message was not sent through a DM chat.
 	var user_id_one : String
 
-	### <summary>
-	### The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
-	### </summary>
+	# The ID of the second DM user, or an empty string if this message was not sent through a DM chat.
 	var user_id_two : String
 
 	func _init(p_ex = null).(p_ex):
@@ -220,9 +166,7 @@ class ChannelPresenceEvent extends NakamaAsyncResult:
 	static func get_result_key() -> String:
 		return "channel_presence_event"
 
-### <summary>
-### A multiplayer match.
-### </summary>
+# A multiplayer match.
 class Match extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -234,34 +178,22 @@ class Match extends NakamaAsyncResult:
 		"self": {"name": "self_user", "type": "UserPresence", "required": true}
 	}
 
-	### <summary>
-	### If this match has an authoritative handler on the server.
-	### </summary>
+	# If this match has an authoritative handler on the server.
 	var authoritative : bool
 
-	### <summary>
-	### The unique match identifier.
-	### </summary>
+	# The unique match identifier.
 	var match_id : String
 
-	### <summary>
-	### A label for the match which can be filtered on.
-	### </summary>
+	# A label for the match which can be filtered on.
 	var label : String
 
-	### <summary>
-	### The presences already in the match.
-	### </summary>
+	# The presences already in the match.
 	var presences : Array # UserPresence
 
-	### <summary>
-	### The number of users currently in the match.
-	### </summary>
+	# The number of users currently in the match.
 	var size : int
 
-	### <summary>
-	### The current user in this match. i.e. Yourself.
-	### </summary>
+	# The current user in this match. i.e. Yourself.
 	var self_user : UserPresence
 
 	func _init(p_ex = null).(p_ex):
@@ -278,9 +210,7 @@ class Match extends NakamaAsyncResult:
 		return "match"
 
 
-### <summary>
-### Some game state update in a match.
-### </summary>
+# Some game state update in a match.
 class MatchData extends NakamaAsyncResult:
 	const _SCHEMA = {
 		"match_id": {"name": "match_id", "type": TYPE_STRING, "required": true},
@@ -289,22 +219,14 @@ class MatchData extends NakamaAsyncResult:
 		"data": {"name": "data", "type": TYPE_STRING, "required": false}
 	}
 
-	### <summary>
-	### The unique match identifier.
-	### </summary>
+	# The unique match identifier.
 	var match_id : String
 
-	### <summary>
-	### The operation code for the state change.
-	### </summary>
-	### <remarks>
-	### This value can be used to mark the type of the contents of the state.
-	### </remarks>
+	# The operation code for the state change.
+	# This value can be used to mark the type of the contents of the state.
 	var op_code : int = 0
 
-	### <summary>
-	### The byte contents of the state change.
-	### </summary>
+	# The byte contents of the state change.
 	var data : String
 
 	func _init(p_ex = null).(p_ex):
@@ -324,9 +246,7 @@ class MatchData extends NakamaAsyncResult:
 		return "match_data"
 
 
-### <summary>
-### A batch of join and leave presences for a match.
-### </summary>
+# A batch of join and leave presences for a match.
 class MatchPresenceEvent extends NakamaAsyncResult:
 	const _SCHEMA = {
 		"match_id": {"name": "match_id", "type": TYPE_STRING, "required": true},
@@ -334,19 +254,13 @@ class MatchPresenceEvent extends NakamaAsyncResult:
 		"leaves": {"name": "leaves", "type": TYPE_ARRAY, "required": false, "content" : "UserPresence"},
 	}
 
-	### <summary>
-	### Presences of users who joined the match.
-	### </summary>
+	# Presences of users who joined the match.
 	var joins : Array
 
-	### <summary>
-	### Presences of users who left the match.
-	### </summary>
+	# Presences of users who left the match.
 	var leaves : Array
 
-	### <summary>
-	### The unique match identifier.
-	### </summary>
+	# The unique match identifier.
 	var match_id : String
 
 	func _init(p_ex = null).(p_ex):
@@ -362,9 +276,7 @@ class MatchPresenceEvent extends NakamaAsyncResult:
 	static func get_result_key() -> String:
 		return "match_presence_event"
 
-### <summary>
-### The result of a successful matchmaker operation sent to the server.
-### </summary>
+# The result of a successful matchmaker operation sent to the server.
 class MatchmakerMatched extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -375,32 +287,20 @@ class MatchmakerMatched extends NakamaAsyncResult:
 		"self": {"name": "self_user", "type": "MatchmakerUser", "required": true}
 	}
 
-	### <summary>
-	### The id used to join the match.
-	### </summary>
-	### <remarks>
-	### A match ID used to join the match.
-	### </remarks>
+	# The id used to join the match.
+	# A match ID used to join the match.
 	var match_id : String
 
-	### <summary>
-	### The ticket sent by the server when the user requested to matchmake for other players.
-	### </summary>
+	# The ticket sent by the server when the user requested to matchmake for other players.
 	var ticket : String
 
-	### <summary>
-	### The token used to join a match.
-	### </summary>
+	# The token used to join a match.
 	var token : String
 
-	### <summary>
-	### The other users matched with this user and the parameters they sent.
-	### </summary>
+	# The other users matched with this user and the parameters they sent.
 	var users : Array # MatchmakerUser
 	
-	### <summary>
-	### The current user who matched with opponents.
-	### </summary>
+	# The current user who matched with opponents.
 	var self_user : MatchmakerUser
 
 	func _init(p_ex = null).(p_ex):
@@ -419,18 +319,14 @@ class MatchmakerMatched extends NakamaAsyncResult:
 		return "matchmaker_matched"
 
 
-### <summary>
-### The matchmaker ticket received from the server.
-### </summary>
+# The matchmaker ticket received from the server.
 class MatchmakerTicket extends NakamaAsyncResult:
 
 	const _SCHEMA = {
 		"ticket": {"name": "ticket", "type": TYPE_STRING, "required": true}
 	}
 
-	### <summary>
-	### The ticket generated by the matchmaker.
-	### </summary>
+	# The ticket generated by the matchmaker.
 	var ticket : String
 
 	func _init(p_ex = null).(p_ex):
@@ -447,9 +343,7 @@ class MatchmakerTicket extends NakamaAsyncResult:
 		return "matchmaker_ticket"
 
 
-### <summary>
-### The user with the parameters they sent to the server when asking for opponents.
-### </summary>
+# The user with the parameters they sent to the server when asking for opponents.
 class MatchmakerUser extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -458,19 +352,13 @@ class MatchmakerUser extends NakamaAsyncResult:
 		"presence": {"name": "presence", "type": "UserPresence", "required": true}
 	}
 
-	### <summary>
-	### The numeric properties which this user asked to matchmake with.
-	### </summary>
+	# The numeric properties which this user asked to matchmake with.
 	var numeric_properties : Dictionary
 
-	### <summary>
-	### The presence of the user.
-	### </summary>
+	# The presence of the user.
 	var presence : UserPresence
 
-	### <summary>
-	### The string properties which this user asked to matchmake with.
-	### </summary>
+	# The string properties which this user asked to matchmake with.
 	var string_properties : Dictionary
 
 	func _init(p_ex = null).(p_ex):
@@ -488,18 +376,14 @@ class MatchmakerUser extends NakamaAsyncResult:
 		return "matchmaker_user"
 
 
-### <summary>
-### Receive status updates for users.
-### </summary>
+# Receive status updates for users.
 class Status extends NakamaAsyncResult:
 
 	const _SCHEMA = {
 		"users": {"name": "users", "type": TYPE_ARRAY, "required": false, "content": "UserPresence"},
 	}
 
-	### <summary>
-	### The status events for the users followed.
-	### </summary>
+	# The status events for the users followed.
 	var presences := Array()
 
 	func _init(p_ex = null).(p_ex):
@@ -516,29 +400,19 @@ class Status extends NakamaAsyncResult:
 		return "status"
 
 
-### <summary>
-### A status update event about other users who've come online or gone offline.
-### </summary>
+# A status update event about other users who've come online or gone offline.
 class StatusPresenceEvent extends NakamaAsyncResult:
 	const _SCHEMA = {
 		"joins": {"name": "joins", "type": TYPE_ARRAY, "required": false, "content" : "UserPresence"},
 		"leaves": {"name": "leaves", "type": TYPE_ARRAY, "required": false, "content" : "UserPresence"},
 	}
 
-	### <summary>
-	### Presences of users who joined the server.
-	### </summary>
-	### <remarks>
-	### This join information is in response to a subscription made to be notified when a user comes online.
-	### </remarks>
+	# Presences of users who joined the server.
+	# This join information is in response to a subscription made to be notified when a user comes online.
 	var joins : Array
 
-	### <summary>
-	### Presences of users who left the server.
-	### </summary>
-	### <remarks>
-	### This leave information is in response to a subscription made to be notified when a user goes offline.
-	### </remarks>
+	# Presences of users who left the server.
+	# This leave information is in response to a subscription made to be notified when a user goes offline.
 	var leaves : Array
 
 	func _init(p_ex = null).(p_ex):
@@ -555,9 +429,7 @@ class StatusPresenceEvent extends NakamaAsyncResult:
 		return "status_presence_event"
 
 
-### <summary>
-### A realtime socket stream on the server.
-### </summary>
+# A realtime socket stream on the server.
 class Stream extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -567,24 +439,16 @@ class Stream extends NakamaAsyncResult:
 		"subject": {"name": "subject", "type": TYPE_STRING, "required": false},
 	}
 
-	### <summary>
-	### The descriptor of the stream. Used with direct chat messages and contains a second user id.
-	### </summary>
+	# The descriptor of the stream. Used with direct chat messages and contains a second user id.
 	var descriptor : String
 
-	### <summary>
-	### Identifies streams which have a context across users like a chat channel room.
-	### </summary>
+	# Identifies streams which have a context across users like a chat channel room.
 	var label : String
 
-	### <summary>
-	### The mode of the stream.
-	### </summary>
+	# The mode of the stream.
 	var mode : int
 
-	### <summary>
-	### The subject of the stream. This is usually a user id.
-	### </summary>
+	# The subject of the stream. This is usually a user id.
 	var subject : String
 
 	func _init(p_ex = null).(p_ex):
@@ -601,13 +465,9 @@ class Stream extends NakamaAsyncResult:
 		return "stream"
 
 
-### <summary>
-### A batch of joins and leaves on the low level stream.
-### </summary>
-### <remarks>
-### Streams are built on to provide abstractions for matches, chat channels, etc. In most cases you'll never need to
-### interact with the low level stream itself.
-### </remarks>
+# A batch of joins and leaves on the low level stream.
+# Streams are built on to provide abstractions for matches, chat channels, etc. In most cases you'll never need to
+# interact with the low level stream itself.
 class StreamPresenceEvent extends NakamaAsyncResult:
 	const _SCHEMA = {
 		"stream": {"name": "stream", "type": "Stream", "required": true},
@@ -615,19 +475,13 @@ class StreamPresenceEvent extends NakamaAsyncResult:
 		"leaves": {"name": "leaves", "type": TYPE_ARRAY, "required": false, "content" : "UserPresence"},
 	}
 
-	### <summary>
-	### Presences of users who left the stream.
-	### </summary>
+	# Presences of users who left the stream.
 	var joins : Array
 
-	### <summary>
-	### Presences of users who joined the stream.
-	### </summary>
+	# Presences of users who joined the stream.
 	var leaves : Array
 
-	### <summary>
-	### The identifier for the stream.
-	### </summary>
+	# The identifier for the stream.
 	var stream : Stream = null
 
 	func _to_string():
@@ -641,9 +495,7 @@ class StreamPresenceEvent extends NakamaAsyncResult:
 		return "stream_presence_event"
 
 
-### <summary>
-### A state change received from a stream.
-### </summary>
+# A state change received from a stream.
 class StreamData extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -653,24 +505,16 @@ class StreamData extends NakamaAsyncResult:
 		"reliable": {"name": "reliable", "type": TYPE_BOOL, "required": false},
 	}
 
-	### <summary>
-	### The user who sent the state change. May be <c>null</c>.
-	### </summary>
+	# The user who sent the state change. May be `null`.
 	var sender : UserPresence = null
 
-	### <summary>
-	### The contents of the state change.
-	### </summary>
+	# The contents of the state change.
 	var state : String
 
-	### <summary>
-	### The identifier for the stream.
-	### </summary>
+	# The identifier for the stream.
 	var stream : Stream
 
-	### <summary>
-	### True if this data was delivered reliably, false otherwise.
-	### </summary>
+	# True if this data was delivered reliably, false otherwise.
 	var reliable : bool
 
 	func _to_string():
@@ -683,13 +527,9 @@ class StreamData extends NakamaAsyncResult:
 	static func get_result_key() -> String:
 		return "stream_data"
 
-### <summary>
-### An object which represents a connected user in the server.
-### </summary>
-### <remarks>
-### The server allows the same user to be connected with multiple sessions. To uniquely identify them a tuple of
-### <c>{ node_id, user_id, session_id }</c> is used which is exposed as this object.
-### </remarks>
+# An object which represents a connected user in the server.
+# The server allows the same user to be connected with multiple sessions. To uniquely identify them a tuple of
+# `{ node_id, user_id, session_id }` is used which is exposed as this object.
 class UserPresence extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -700,29 +540,19 @@ class UserPresence extends NakamaAsyncResult:
 		"user_id": {"name": "user_id", "type": TYPE_STRING, "required": true},
 	}
 
-	### <summary>
-	### If this presence generates stored events like persistent chat messages or notifications.
-	### </summary>
+	# If this presence generates stored events like persistent chat messages or notifications.
 	var persistence : bool
 
-	### <summary>
-	### The session id of the user.
-	### </summary>
+	# The session id of the user.
 	var session_id : String
 
-	### <summary>
-	### The status of the user with the presence on the server.
-	### </summary>
+	# The status of the user with the presence on the server.
 	var status : String
 
-	### <summary>
-	### The username for the user.
-	### </summary>
+	# The username for the user.
 	var username : String
 
-	### <summary>
-	### The id of the user.
-	### </summary>
+	# The id of the user.
 	var user_id : String
 
 	func _init(p_ex = null).(p_ex):

--- a/addons/com.heroiclabs.nakama/api/NakamaRTMessage.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaRTMessage.gd
@@ -1,9 +1,7 @@
 extends Reference
 class_name NakamaRTMessage
 
-### <summary>
-### Send a channel join message to the server.
-### </summary>
+# Send a channel join message to the server.
 class ChannelJoin:
 
 	const _SCHEMA = {
@@ -14,17 +12,11 @@ class ChannelJoin:
 	}
 
 	enum ChannelType {
-		### <summary>
-		### A chat room which can be created dynamically with a name.
-		### </summary>
+		# A chat room which can be created dynamically with a name.
 		Room = 1,
-		### <summary>
-		### A private chat between two users.
-		### </summary>
+		# A private chat between two users.
 		DirectMessage = 2,
-		### <summary>
-		### A chat within a group on the server.
-		### </summary>
+		# A chat within a group on the server.
 		Group = 3
 	}
 
@@ -49,9 +41,7 @@ class ChannelJoin:
 		return "ChannelJoin<persistence=%s, hidden=%s, target=%s, type=%d>" % [persistence, hidden, target, type]
 
 
-### <summary>
-### A leave message for a match on the server.
-### </summary>
+# A leave message for a match on the server.
 class ChannelLeave extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -96,9 +86,7 @@ class ChannelMessageRemove extends NakamaAsyncResult:
 		return "ChannelMessageRemove<channel_id=%s, message_id=%s>" % [channel_id, message_id]
 
 
-### <summary>
-### Send a chat message to a channel on the server.
-### </summary>
+# Send a chat message to a channel on the server.
 class ChannelMessageSend extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -149,9 +137,7 @@ class ChannelMessageUpdate extends NakamaAsyncResult:
 	func _to_string():
 		return "ChannelMessageUpdate<channel_id=%s, message_id=%s, content=%s>" % [channel_id, message_id, content]
 
-### <summary>
-### A create message for a match on the server.
-### </summary>
+# A create message for a match on the server.
 class MatchCreate extends NakamaAsyncResult:
 
 	const _SCHEMA = {}
@@ -169,9 +155,7 @@ class MatchCreate extends NakamaAsyncResult:
 		return "MatchCreate<>"
 
 
-### <summary>
-### A join message for a match on the server.
-### </summary>
+# A join message for a match on the server.
 class MatchJoin extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -198,9 +182,7 @@ class MatchJoin extends NakamaAsyncResult:
 		return "MatchJoin<match_id=%s, token=%s, metadata=%s>" % [match_id, token, metadata]
 
 
-### <summary>
-### A leave message for a match on the server.
-### </summary>
+# A leave message for a match on the server.
 class MatchLeave extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -221,9 +203,7 @@ class MatchLeave extends NakamaAsyncResult:
 		return "MatchLeave<match_id=%s>" % [match_id]
 
 
-### <summary>
-### Send new state to a match on the server.
-### </summary>
+# Send new state to a match on the server.
 class MatchDataSend extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -254,9 +234,7 @@ class MatchDataSend extends NakamaAsyncResult:
 		return "MatchDataSend<match_id=%s, op_code=%s, presences=%s, data=%s>" % [match_id, op_code, presences, data]
 
 
-### <summary>
-### Add the user to the matchmaker pool with properties.
-### </summary>
+# Add the user to the matchmaker pool with properties.
 class MatchmakerAdd extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -293,9 +271,7 @@ class MatchmakerAdd extends NakamaAsyncResult:
 		return "MatchmakerAdd<query=%s, max_count=%d, min_count=%d, numeric_properties=%s, string_properties=%s>" % [query, max_count, min_count, numeric_properties, string_properties]
 
 
-### <summary>
-### Remove the user from the matchmaker pool by ticket.
-### </summary>
+# Remove the user from the matchmaker pool by ticket.
 class MatchmakerRemove extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -317,9 +293,7 @@ class MatchmakerRemove extends NakamaAsyncResult:
 		return "MatchmakerRemove<ticket=%s>" % [ticket]
 
 
-### <summary>
-### Follow one or more other users for status updates.
-### </summary>
+# Follow one or more other users for status updates.
 class StatusFollow extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -344,9 +318,7 @@ class StatusFollow extends NakamaAsyncResult:
 		return "StatusFollow<user_ids=%s, usernames=%s>" % [user_ids, usernames]
 
 
-### <summary>
-### Unfollow one or more users on the server.
-### </summary>
+# Unfollow one or more users on the server.
 class StatusUnfollow extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -368,9 +340,7 @@ class StatusUnfollow extends NakamaAsyncResult:
 		return "StatusUnfollow<user_ids=%s>" % [user_ids]
 
 
-### <summary>
-### Unfollow one or more users on the server.
-### </summary>
+# Unfollow one or more users on the server.
 class StatusUpdate extends NakamaAsyncResult:
 
 	const _SCHEMA = {

--- a/addons/com.heroiclabs.nakama/api/NakamaStorageObjectId.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaStorageObjectId.gd
@@ -1,24 +1,16 @@
 extends Reference
 class_name NakamaStorageObjectId
 
-### <summary>
-### The collection which stores the object.
-### </summary>
+# The collection which stores the object.
 var collection : String
 
-### <summary>
-### The key of the object within the collection.
-### </summary>
+# The key of the object within the collection.
 var key : String
 
-### <summary>
-### The user owner of the object.
-### </summary>
+# The user owner of the object.
 var user_id : String
 
-### <summary>
-### The version hash of the object.
-### </summary>
+# The version hash of the object.
 var version : String
 
 func _init(p_collection, p_key, p_user_id = "", p_version = ""):

--- a/addons/com.heroiclabs.nakama/client/NakamaClient.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaClient.gd
@@ -1,8 +1,6 @@
 extends Reference
 
-### <summary>
-### A client for the API in Nakama server.
-### </summary>
+# A client for the API in Nakama server.
 class_name NakamaClient
 
 const ChannelType = NakamaRTMessage.ChannelJoin.ChannelType
@@ -13,29 +11,19 @@ func _no_set(_p):
 func _no_get():
 	return null
 
-### <summary>
-### The host address of the server. Defaults to "127.0.0.1".
-### </summary>
+# The host address of the server. Defaults to "127.0.0.1".
 var host : String setget _no_set
 
-### <summary>
-### The port number of the server. Defaults to 7350.
-### </summary>
+# The port number of the server. Defaults to 7350.
 var port : int setget _no_set
 
-### <summary>
-### The protocol scheme used to connect with the server. Must be either "http" or "https".
-### </summary>
+# The protocol scheme used to connect with the server. Must be either "http" or "https".
 var scheme : String setget _no_set
 
-### <summary>
-### The key used to authenticate with the server without a session. Defaults to "defaultkey".
-### </summary>
+# The key used to authenticate with the server without a session. Defaults to "defaultkey".
 var server_key : String = "defaultkey" setget _no_set
 
-### <summary>
-### Set the timeout in seconds on requests sent to the server.
-### </summary>
+# Set the timeout in seconds on requests sent to the server.
 var timeout : int
 
 var logger : NakamaLogger = null
@@ -57,14 +45,10 @@ func _init(p_adapter : NakamaHTTPAdapter,
 	logger = p_adapter.logger
 	_api_client = NakamaAPI.ApiClient.new(scheme + "://" + host + ":" + str(port), p_adapter, NakamaAPI, p_timeout)
 
-### <summary>
-### Restore a session from the auth token.
-### </summary>
-### <remarks>
-### A <c>null</c> or empty authentication token will return null.
-### </remarks>
-### <param name="authToken">The authentication token to restore as a session.</param>
-### <returns>A session.</returns>
+# Restore a session from the auth token.
+# A `null` or empty authentication token will return `null`.
+# @param authToken - The authentication token to restore as a session.
+# Returns a session.
 static func restore_session(auth_token : String):
 	return NakamaSession.new(auth_token, false)
 
@@ -78,34 +62,28 @@ func _parse_auth(p_session) -> NakamaSession:
 		return NakamaSession.new(null, false, p_session.get_exception())
 	return NakamaSession.new(p_session.token, p_session.created)
 
-### <summary>
-### Add one or more friends by id or username.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_ids">The ids of the users to add or invite as friends.</param>
-### <param name="p_usernames">The usernames of the users to add as friends.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Add one or more friends by id or username.
+# @param p_session - The session of the user.
+# @param p_ids - The ids of the users to add or invite as friends.
+# @param p_usernames - The usernames of the users to add as friends.
+# Returns a task which represents the asynchronous operation.
 func add_friends_async(p_session : NakamaSession, p_ids : PoolStringArray, p_usernames = null) -> NakamaAsyncResult:
 	return _api_client.add_friends_async(p_session.token, p_ids, p_usernames)
 
-### <summary>
-### Add one or more users to the group.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_group_id">The id of the group to add users into.</param>
-### <param name="p_ids">The ids of the users to add or invite to the group.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Add one or more users to the group.
+# @param p_session - The session of the user.
+# @param p_group_id - The id of the group to add users into.
+# @param p_ids - The ids of the users to add or invite to the group.
+# Returns a task which represents the asynchronous operation.
 func add_group_users_async(p_session : NakamaSession, p_group_id : String, p_ids : PoolStringArray) -> NakamaAsyncResult:
 	return _api_client.add_group_users_async(p_session.token, p_group_id, p_ids);
 
-### <summary>
-### Authenticate a user with a custom id.
-### </summary>
-### <param name="p_id">A custom identifier usually obtained from an external authentication service.</param>
-### <param name="p_username">A username used to create the user. May be <c>null</c>.</param>
-### <param name="p_create">If the user should be created when authenticated.</param>
-### <param name="p_vars">Extra information that will be bundled in the session token.</param>
-### <returns>A task which resolves to a session object.</returns>
+# Authenticate a user with a custom id.
+# @param p_id - A custom identifier usually obtained from an external authentication service.
+# @param p_username - A username used to create the user. May be `null`.
+# @param p_create - If the user should be created when authenticated.
+# @param p_vars - Extra information that will be bundled in the session token.
+# Returns a task which resolves to a session object.
 func authenticate_custom_async(p_id : String, p_username = null, p_create : bool = true, p_vars = null) -> NakamaSession:
 	return _parse_auth(yield(_api_client.authenticate_custom_async(server_key, "",
 		NakamaAPI.ApiAccountCustom.create(NakamaAPI, {
@@ -113,14 +91,12 @@ func authenticate_custom_async(p_id : String, p_username = null, p_create : bool
 			"vars": p_vars
 		}), p_create, p_username), "completed"))
 
-### <summary>
-### Authenticate a user with a device id.
-### </summary>
-### <param name="p_id">A device identifier usually obtained from a platform API.</param>
-### <param name="p_username">A username used to create the user. May be <c>null</c>.</param>
-### <param name="p_create">If the user should be created when authenticated.</param>
-### <param name="p_vars">Extra information that will be bundled in the session token.</param>
-### <returns>A task which resolves to a session object.</returns>
+# Authenticate a user with a device id.
+# @param p_id - A device identifier usually obtained from a platform API.
+# @param p_username - A username used to create the user. May be `null`.
+# @param p_create - If the user should be created when authenticated.
+# @param p_vars - Extra information that will be bundled in the session token.
+# Returns a task which resolves to a session object.
 func authenticate_device_async(p_id : String, p_username = null, p_create : bool = true, p_vars = null) -> NakamaSession:
 	return _parse_auth(yield(_api_client.authenticate_device_async(server_key, "",
 		NakamaAPI.ApiAccountDevice.create(NakamaAPI, {
@@ -128,15 +104,13 @@ func authenticate_device_async(p_id : String, p_username = null, p_create : bool
 			"vars": p_vars
 		}), p_create, p_username), "completed"))
 
-### <summary>
-### Authenticate a user with an email and password.
-### </summary>
-### <param name="p_email">The email address of the user.</param>
-### <param name="p_password">The password for the user.</param>
-### <param name="p_username">A username used to create the user. May be <c>null</c>.</param>
-### <param name="p_create">If the user should be created when authenticated.</param>
-### <param name="p_vars">Extra information that will be bundled in the session token.</param>
-### <returns>A task which resolves to a session object.</returns>
+# Authenticate a user with an email and password.
+# @param p_email - The email address of the user.
+# @param p_password - The password for the user.
+# @param p_username - A username used to create the user. May be `null`.
+# @param p_create - If the user should be created when authenticated.
+# @param p_vars - Extra information that will be bundled in the session token.
+# Returns a task which resolves to a session object.
 func authenticate_email_async(p_email : String, p_password : String, p_username = null, p_create : bool = true, p_vars = null) -> NakamaSession:
 	return _parse_auth(yield(_api_client.authenticate_email_async(server_key, "",
 		NakamaAPI.ApiAccountEmail.create(NakamaAPI, {
@@ -145,15 +119,13 @@ func authenticate_email_async(p_email : String, p_password : String, p_username 
 			"vars": p_vars
 		}), p_create, p_username), "completed"))
 
-### <summary>
-### Authenticate a user with a Facebook auth token.
-### </summary>
-### <param name="p_token">An OAuth access token from the Facebook SDK.</param>
-### <param name="p_username">A username used to create the user. May be <c>null</c>.</param>
-### <param name="p_create">If the user should be created when authenticated.</param>
-### <param name="p_import">If the Facebook friends should be imported.</param>
-### <param name="p_vars">Extra information that will be bundled in the session token.</param>
-### <returns>A task which resolves to a session object.</returns>
+# Authenticate a user with a Facebook auth token.
+# @param p_token - An OAuth access token from the Facebook SDK.
+# @param p_username - A username used to create the user. May be `null`.
+# @param p_create - If the user should be created when authenticated.
+# @param p_import - If the Facebook friends should be imported.
+# @param p_vars - Extra information that will be bundled in the session token.
+# Returns a task which resolves to a session object.
 func authenticate_facebook_async(p_token : String, p_username = null, p_create : bool = true, p_import : bool = true, p_vars = null) -> NakamaSession:
 	return _parse_auth(yield(_api_client.authenticate_facebook_async(server_key, "",
 		NakamaAPI.ApiAccountFacebook.create(NakamaAPI, {
@@ -161,19 +133,17 @@ func authenticate_facebook_async(p_token : String, p_username = null, p_create :
 			"vars": p_vars
 		}), p_create, p_username, p_import), "completed"))
 
-### <summary>
-### Authenticate a user with Apple Game Center.
-### </summary>
-### <param name="p_bundle_id">The bundle id of the Game Center application.</param>
-### <param name="p_player_id">The player id of the user in Game Center.</param>
-### <param name="p_public_key_url">The URL for the public encryption key.</param>
-### <param name="p_salt">A random <c>NSString</c> used to compute the hash and keep it randomized.</param>
-### <param name="p_signature">The verification signature data generated.</param>
-### <param name="p_timestamp_seconds">The date and time that the signature was created.</param>
-### <param name="p_username">A username used to create the user. May be <c>null</c>.</param>
-### <param name="p_create">If the user should be created when authenticated.</param>
-### <param name="p_vars">Extra information that will be bundled in the session token.</param>
-### <returns>A task which resolves to a session object.</returns>
+# Authenticate a user with Apple Game Center.
+# @param p_bundle_id - The bundle id of the Game Center application.
+# @param p_player_id - The player id of the user in Game Center.
+# @param p_public_key_url - The URL for the public encryption key.
+# @param p_salt - A random `NSString` used to compute the hash and keep it randomized.
+# @param p_signature - The verification signature data generated.
+# @param p_timestamp_seconds - The date and time that the signature was created.
+# @param p_username - A username used to create the user. May be `null`.
+# @param p_create - If the user should be created when authenticated.
+# @param p_vars - Extra information that will be bundled in the session token.
+# Returns a task which resolves to a session object.
 func authenticate_game_center_async(p_bundle_id : String, p_player_id : String, p_public_key_url : String,
 		p_salt : String, p_signature : String, p_timestamp_seconds : String, p_username = null, p_create : bool = true, p_vars = null) -> NakamaSession:
 	return _parse_auth(yield(_api_client.authenticate_game_center_async(server_key, "",
@@ -187,14 +157,12 @@ func authenticate_game_center_async(p_bundle_id : String, p_player_id : String, 
 			"vars": p_vars
 		}), p_create, p_username), "completed"))
 
-### <summary>
-### Authenticate a user with a Google auth token.
-### </summary>
-### <param name="p_token">An OAuth access token from the Google SDK.</param>
-### <param name="p_username">A username used to create the user. May be <c>null</c>.</param>
-### <param name="p_create">If the user should be created when authenticated.</param>
-### <param name="p_vars">Extra information that will be bundled in the session token.</param>
-### <returns>A task which resolves to a session object.</returns>
+# Authenticate a user with a Google auth token.
+# @param p_token - An OAuth access token from the Google SDK.
+# @param p_username - A username used to create the user. May be `null`.
+# @param p_create - If the user should be created when authenticated.
+# @param p_vars - Extra information that will be bundled in the session token.
+# Returns a task which resolves to a session object.
 func authenticate_google_async(p_token : String, p_username = null, p_create : bool = true, p_vars = null) -> NakamaSession:
 	return _parse_auth(yield(_api_client.authenticate_google_async(server_key, "",
 		NakamaAPI.ApiAccountGoogle.create(NakamaAPI, {
@@ -202,14 +170,12 @@ func authenticate_google_async(p_token : String, p_username = null, p_create : b
 			"vars": p_vars
 		}), p_create, p_username), "completed"))
 
-### <summary>
-### Authenticate a user with a Steam auth token.
-### </summary>
-### <param name="p_token">An authentication token from the Steam network.</param>
-### <param name="p_username">A username used to create the user. May be <c>null</c>.</param>
-### <param name="p_create">If the user should be created when authenticated.</param>
-### <param name="p_vars">Extra information that will be bundled in the session token.</param>
-### <returns>A task which resolves to a session object.</returns>
+# Authenticate a user with a Steam auth token.
+# @param p_token - An authentication token from the Steam network.
+# @param p_username - A username used to create the user. May be `null`.
+# @param p_create - If the user should be created when authenticated.
+# @param p_vars - Extra information that will be bundled in the session token.
+# Returns a task which resolves to a session object.
 func authenticate_steam_async(p_token : String, p_username = null, p_create : bool = true, p_vars = null) -> NakamaSession:
 	return _parse_auth(yield(_api_client.authenticate_steam_async(server_key, "",
 		NakamaAPI.ApiAccountSteam.create(NakamaAPI, {
@@ -217,27 +183,23 @@ func authenticate_steam_async(p_token : String, p_username = null, p_create : bo
 			"vars": p_vars
 		}), p_create, p_username), "completed"))
 
-### <summary>
-### Block one or more friends by id or username.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_ids">The ids of the users to block.</param>
-### <param name="p_usernames">The usernames of the users to block.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Block one or more friends by id or username.
+# @param p_session - The session of the user.
+# @param p_ids - The ids of the users to block.
+# @param p_usernames - The usernames of the users to block.
+# Returns a task which represents the asynchronous operation.
 func block_friends_async(p_session : NakamaSession, p_ids : PoolStringArray, p_usernames = null) -> NakamaAsyncResult:
 	return _api_client.block_friends_async(p_session.token, p_ids, p_usernames);
 
-### <summary>
-### Create a group.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_name">The name for the group.</param>
-### <param name="p_description">A description for the group.</param>
-### <param name="p_avatar_url">An avatar url for the group.</param>
-### <param name="p_lang_tag">A language tag in BCP-47 format for the group.</param>
-### <param name="p_open">If the group should have open membership.</param>
-### <param name="p_max_count">The maximum number of members allowed.</param>
-### <returns>A task which resolves to a new group object.</returns>
+# Create a group.
+# @param p_session - The session of the user.
+# @param p_name - The name for the group.
+# @param p_description - A description for the group.
+# @param p_avatar_url - An avatar url for the group.
+# @param p_lang_tag - A language tag in BCP-47 format for the group.
+# @param p_open - If the group should have open membership.
+# @param p_max_count - The maximum number of members allowed.
+# Returns a task which resolves to a new group object.
 func create_group_async(p_session : NakamaSession, p_name : String, p_description : String = "",
 		p_avatar_url = null, p_lang_tag = null, p_open : bool = true, p_max_count : int = 100): # -> NakamaAPI.ApiGroup:
 	return _api_client.create_group_async(p_session.token,
@@ -250,49 +212,39 @@ func create_group_async(p_session : NakamaSession, p_name : String, p_descriptio
 			"open": p_open
 		}))
 
-### <summary>
-### Delete one more or users by id or username from friends.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_ids">The user ids to remove as friends.</param>
-### <param name="p_usernames">The usernames to remove as friends.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Delete one more or users by id or username from friends.
+# @param p_session - The session of the user.
+# @param p_ids - The user ids to remove as friends.
+# @param p_usernames - The usernames to remove as friends.
+# Returns a task which represents the asynchronous operation.
 func delete_friends_async(p_session : NakamaSession, p_ids : PoolStringArray, p_usernames = null) -> NakamaAsyncResult:
 	return _api_client.delete_friends_async(p_session.token, p_ids, p_usernames)
 
-### <summary>
-### Delete a group by id.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_group_id">The group id to to remove.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Delete a group by id.
+# @param p_session - The session of the user.
+# @param p_group_id - The group id to to remove.
+# Returns a task which represents the asynchronous operation.
 func delete_group_async(p_session : NakamaSession, p_group_id : String) -> NakamaAsyncResult:
 	return _api_client.delete_group_async(p_session.token, p_group_id)
 
-### <summary>
-### Delete a leaderboard record.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_leaderboard_id">The id of the leaderboard with the record to be deleted.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Delete a leaderboard record.
+# @param p_session - The session of the user.
+# @param p_leaderboard_id - The id of the leaderboard with the record to be deleted.
+# Returns a task which represents the asynchronous operation.
 func delete_leaderboard_record_async(p_session : NakamaSession, p_leaderboard_id : String) -> NakamaAsyncResult:
 	return _api_client.delete_leaderboard_record_async(p_session.token, p_leaderboard_id)
 
-### <summary>
-### Delete one or more notifications by id.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_ids">The notification ids to remove.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Delete one or more notifications by id.
+# @param p_session - The session of the user.
+# @param p_ids - The notification ids to remove.
+# Returns a task which represents the asynchronous operation.
 func delete_notifications_async(p_session : NakamaSession, p_ids : PoolStringArray) -> NakamaAsyncResult:
 	return _api_client.delete_notifications_async(p_session.token, p_ids)
 
-### <summary>
-### Delete one or more storage objects.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_ids">The ids of the objects to delete.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Delete one or more storage objects.
+# @param p_session - The session of the user.
+# @param p_ids - The ids of the objects to delete.
+# Returns a task which represents the asynchronous operation.
 func delete_storage_objects_async(p_session : NakamaSession, p_ids : Array) -> NakamaAsyncResult:
 	var ids : Array = []
 	for id in p_ids:
@@ -305,137 +257,111 @@ func delete_storage_objects_async(p_session : NakamaSession, p_ids : Array) -> N
 			"object_ids": ids
 		}))
 
-### <summary>
-### Fetch the user account owned by the session.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <returns>A task which resolves to the account object.</returns>
+# Fetch the user account owned by the session.
+# @param p_session - The session of the user.
+# Returns a task which resolves to the account object.
 func get_account_async(p_session : NakamaSession): # -> NakamaAPI.ApiAccount:
 	return _api_client.get_account_async(p_session.token)
 
-### <summary>
-### Fetch one or more users by id, usernames, and Facebook ids.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_ids">The IDs of the users to retrieve.</param>
-### <param name="p_usernames">The usernames of the users to retrieve.</param>
-### <param name="p_facebook_ids">The facebook IDs of the users to retrieve.</param>
-### <returns>A task which resolves to a collection of user objects.</returns>
+# Fetch one or more users by id, usernames, and Facebook ids.
+# @param p_session - The session of the user.
+# @param p_ids - The IDs of the users to retrieve.
+# @param p_usernames - The usernames of the users to retrieve.
+# @param p_facebook_ids - The facebook IDs of the users to retrieve.
+# Returns a task which resolves to a collection of user objects.
 func get_users_async(p_session : NakamaSession, p_ids : PoolStringArray, p_usernames = null, p_facebook_ids = null): # -> NakamaAPI.ApiUsers:
 	return _api_client.get_users_async(p_session.token, p_ids, p_usernames, p_facebook_ids)
 
-### <summary>
-### Import Facebook friends and add them to the user's account.
-### </summary>
-### <remarks>
-### The server will import friends when the user authenticates with Facebook. This function can be used to be
-### explicit with the import operation.
-### </remarks>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_token">An OAuth access token from the Facebook SDK.</param>
-### <param name="p_reset">If the Facebook friend import for the user should be reset.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Import Facebook friends and add them to the user's account.
+# The server will import friends when the user authenticates with Facebook. This function can be used to be
+# explicit with the import operation.
+# @param p_session - The session of the user.
+# @param p_token - An OAuth access token from the Facebook SDK.
+# @param p_reset - If the Facebook friend import for the user should be reset.
+# Returns a task which represents the asynchronous operation.
 func import_facebook_friends_async(p_session : NakamaSession, p_token : String, p_reset = null) -> NakamaAsyncResult:
 	return _api_client.import_facebook_friends_async(p_session.token,
 		NakamaAPI.ApiAccountFacebook.create(NakamaAPI, {
 			"token": p_token
 		}), p_reset)
 
-### <summary>
-### Join a group if it has open membership or request to join it.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_group_id">The ID of the group to join.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Join a group if it has open membership or request to join it.
+# @param p_session - The session of the user.
+# @param p_group_id - The ID of the group to join.
+# Returns a task which represents the asynchronous operation.
 func join_group_async(p_session : NakamaSession, p_group_id : String) -> NakamaAsyncResult:
 	return _api_client.join_group_async(p_session.token, p_group_id)
 
-### <summary>
-### Join a tournament by ID.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_tournament_id">The ID of the tournament to join.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Join a tournament by ID.
+# @param p_session - The session of the user.
+# @param p_tournament_id - The ID of the tournament to join.
+# Returns a task which represents the asynchronous operation.
 func JoinTournamentAsync(p_session : NakamaSession, p_tournament_id : String) -> NakamaAsyncResult:
 	return _api_client.join_tournament_async(p_session.token, p_tournament_id)
 
-### <summary>
-### Kick one or more users from the group.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_group_id">The ID of the group.</param>
-### <param name="p_ids">The IDs of the users to kick.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Kick one or more users from the group.
+# @param p_session - The session of the user.
+# @param p_group_id - The ID of the group.
+# @param p_ids - The IDs of the users to kick.
+# Returns a task which represents the asynchronous operation.
 func kick_group_users_async(p_session : NakamaSession, p_group_id : String, p_ids : PoolStringArray) -> NakamaAsyncResult:
 	return _api_client.kick_group_users_async(p_session.token, p_group_id, p_ids)
 
-### <summary>
-### Leave a group by ID.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_group_id">The ID of the group to leave.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Leave a group by ID.
+# @param p_session - The session of the user.
+# @param p_group_id - The ID of the group to leave.
+# Returns a task which represents the asynchronous operation.
 func leave_group_async(p_session : NakamaSession, p_group_id : String) -> NakamaAsyncResult:
 	return _api_client.leave_group_async(p_session.token, p_group_id)
 
-### <summary>
-### Link a custom ID to the user account owned by the session.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_id">A custom identifier usually obtained from an external authentication service.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Link a custom ID to the user account owned by the session.
+# @param p_session - The session of the user.
+# @param p_id - A custom identifier usually obtained from an external authentication service.
+# Returns a task which represents the asynchronous operation.
 func link_custom_async(p_session : NakamaSession, p_id : String) -> NakamaAsyncResult:
 	return _api_client.link_custom_async(p_session.token, NakamaAPI.ApiAccountCustom.create(NakamaAPI, {
 		"id": p_id
 	}))
 
-### <summary>
-### Link a device ID to the user account owned by the session.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_id">A device identifier usually obtained from a platform API.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Link a device ID to the user account owned by the session.
+# @param p_session - The session of the user.
+# @param p_id - A device identifier usually obtained from a platform API.
+# Returns a task which represents the asynchronous operation.
 func link_device_async(p_session : NakamaSession, p_id : String) -> NakamaAsyncResult:
 	return _api_client.link_device_async(p_session.token, NakamaAPI.ApiAccountDevice.create(NakamaAPI, {
 		"id": p_id
 	}))
 
-### <summary>
-### Link an email with password to the user account owned by the session.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_email">The email address of the user.</param>
-### <param name="p_password">The password for the user.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Link an email with password to the user account owned by the session.
+# @param p_session - The session of the user.
+# @param p_email - The email address of the user.
+# @param p_password - The password for the user.
+# Returns a task which represents the asynchronous operation.
 func link_email_async(p_session : NakamaSession, p_email : String, p_password : String) -> NakamaAsyncResult:
 	return _api_client.link_email_async(p_session.token, NakamaAPI.ApiAccountEmail.create(NakamaAPI, {
 		"email": p_email,
 		"password": p_password
 	}))
 
-### <summary>
-### Link a Facebook profile to a user account.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_token">An OAuth access token from the Facebook SDK.</param>
-### <param name="p_import">If the Facebook friends should be imported.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Link a Facebook profile to a user account.
+# @param p_session - The session of the user.
+# @param p_token - An OAuth access token from the Facebook SDK.
+# @param p_import - If the Facebook friends should be imported.
+# Returns a task which represents the asynchronous operation.
 func link_facebook_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
 	return _api_client.link_facebook_async(p_session.token, NakamaAPI.ApiAccountFacebook.create(NakamaAPI, {
 		"token": p_token
 	}))
 
-### <summary>
-### Link a Game Center profile to a user account.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_bundle_id">The bundle ID of the Game Center application.</param>
-### <param name="p_player_id">The player ID of the user in Game Center.</param>
-### <param name="p_public_key_url">The URL for the public encryption key.</param>
-### <param name="p_salt">A random <c>NSString</c> used to compute the hash and keep it randomized.</param>
-### <param name="p_signature">The verification signature data generated.</param>
-### <param name="p_timestamp_seconds">The date and time that the signature was created.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Link a Game Center profile to a user account.
+# @param p_session - The session of the user.
+# @param p_bundle_id - The bundle ID of the Game Center application.
+# @param p_player_id - The player ID of the user in Game Center.
+# @param p_public_key_url - The URL for the public encryption key.
+# @param p_salt - A random `NSString` used to compute the hash and keep it randomized.
+# @param p_signature - The verification signature data generated.
+# @param p_timestamp_seconds - The date and time that the signature was created.
+# Returns a task which represents the asynchronous operation.
 func link_game_center_async(p_session : NakamaSession,
 		p_bundle_id : String, p_player_id : String, p_public_key_url : String, p_salt : String, p_signature : String, p_timestamp_seconds) -> NakamaAsyncResult:
 	return _api_client.link_game_center_async(p_session.token,
@@ -448,226 +374,189 @@ func link_game_center_async(p_session : NakamaSession,
 			"timestamp_seconds": p_timestamp_seconds,
 		}))
 
-### <summary>
-### Link a Google profile to a user account.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_token">An OAuth access token from the Google SDK.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Link a Google profile to a user account.
+# @param p_session - The session of the user.
+# @param p_token - An OAuth access token from the Google SDK.
+# Returns a task which represents the asynchronous operation.
 func link_google_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
 	return _api_client.link_google_async(p_session.token, NakamaAPI.ApiAccountGoogle.create(NakamaAPI, {
 		"token": p_token
 	}))
 
-### <summary>
-### Link a Steam profile to a user account.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_token">An authentication token from the Steam network.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Link a Steam profile to a user account.
+# @param p_session - The session of the user.
+# @param p_token - An authentication token from the Steam network.
+# Returns a task which represents the asynchronous operation.
 func link_steam_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
 	return _api_client.link_steam_async(p_session.token, NakamaAPI.ApiAccountSteam.create(NakamaAPI, {
 		"token": p_token
 	}))
 
-### <summary>
-### List messages from a chat channel.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_channel_id">The id of the chat channel.</param>
-### <param name="p_limit">The number of chat messages to list.</param>
-### <param name="forward">Fetch messages forward from the current cursor (or the start).</param>
-### <param name="p_cursor">A cursor for the current position in the messages history to list.</param>
-### <returns>A task which resolves to the channel message list object.</returns>
+# List messages from a chat channel.
+# @param p_session - The session of the user.
+# @param p_channel_id - The id of the chat channel.
+# @param p_limit - The number of chat messages to list.
+# @param forward - Fetch messages forward from the current cursor (or the start).
+# @param p_cursor - A cursor for the current position in the messages history to list.
+# Returns a task which resolves to the channel message list object.
 func list_channel_messages_async(p_session : NakamaSession, p_channel_id : String, limit : int = 1,
 		forward : bool = true, cursor = null): # -> NakamaAPI.ApiChannelMessageList:
 	return _api_client.list_channel_messages_async(p_session.token, p_channel_id, limit, forward, cursor)
 
-### <summary>
-### List of friends of the current user.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_state">Filter by friendship state.</param>
-### <param name="p_limit">The number of friends to list.</param>
-### <param name="p_cursor">A cursor for the current position in the friends list.</param>
-### <returns>A task which resolves to the friend objects.</returns>
+# List of friends of the current user.
+# @param p_session - The session of the user.
+# @param p_state - Filter by friendship state.
+# @param p_limit - The number of friends to list.
+# @param p_cursor - A cursor for the current position in the friends list.
+# Returns a task which resolves to the friend objects.
 func list_friends_async(p_session : NakamaSession, p_state = null, p_limit = null, p_cursor = null): # -> NakamaAPI.ApiFriendList:
 	return _api_client.list_friends_async(p_session.token, p_limit, p_state, p_cursor)
 
-### <summary>
-### List all users part of the group.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_group_id">The ID of the group.</param>
-### <param name="p_state">Filter by group membership state.</param>
-### <param name="p_limit">The number of groups to list.</param>
-### <param name="p_cursor">A cursor for the current position in the group listing.</param>
-### <returns>A task which resolves to the group user objects.</returns>
+# List all users part of the group.
+# @param p_session - The session of the user.
+# @param p_group_id - The ID of the group.
+# @param p_state - Filter by group membership state.
+# @param p_limit - The number of groups to list.
+# @param p_cursor - A cursor for the current position in the group listing.
+# Returns a task which resolves to the group user objects.
 func list_group_users_async(p_session : NakamaSession, p_group_id : String, p_state = null, p_limit = null, p_cursor = null): # -> NakamaAPI.ApiGroupUserList:
 	return _api_client.list_group_users_async(p_session.token, p_group_id, p_limit, p_state, p_cursor)
 
-### <summary>
-### List groups on the server.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_name">The name filter to apply to the group list.</param>
-### <param name="p_limit">The number of groups to list.</param>
-### <param name="p_cursor">A cursor for the current position in the groups to list.</param>
-### <returns>A task to resolve group objects.</returns>
+# List groups on the server.
+# @param p_session - The session of the user.
+# @param p_name - The name filter to apply to the group list.
+# @param p_limit - The number of groups to list.
+# @param p_cursor - A cursor for the current position in the groups to list.
+# Returns a task to resolve group objects.
 func list_groups_async(p_session : NakamaSession, p_name = null, p_limit : int = 1, p_cursor = null): # -> NakamaAPI.ApiGroupList:
 	return _api_client.list_groups_async(p_session.token, p_name, p_cursor, p_limit)
 
-### <summary>
-### List records from a leaderboard.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_leaderboard_id">The ID of the leaderboard to list.</param>
-### <param name="p_owner_ids">Record owners to fetch with the list of records.</param>
-### <param name="p_expiry">Expiry in seconds (since epoch) to begin fetching records from. Optional. 0 means from current time.</param>
-### <param name="p_limit">The number of records to list.</param>
-### <param name="p_cursor">A cursor for the current position in the leaderboard records to list.</param>
-### <returns>A task which resolves to the leaderboard record objects.</returns>
+# List records from a leaderboard.
+# @param p_session - The session of the user.
+# @param p_leaderboard_id - The ID of the leaderboard to list.
+# @param p_owner_ids - Record owners to fetch with the list of records.
+# @param p_expiry - Expiry in seconds (since epoch) to begin fetching records from. Optional. 0 means from current time.
+# @param p_limit - The number of records to list.
+# @param p_cursor - A cursor for the current position in the leaderboard records to list.
+# Returns a task which resolves to the leaderboard record objects.
 func list_leaderboard_records_async(p_session : NakamaSession,
 		p_leaderboard_id : String, p_owner_ids = null, p_expiry = null, p_limit : int = 1, p_cursor = null): # -> NakamaAPI.ApiLeaderboardRecordList:
 	return _api_client.list_leaderboard_records_async(p_session.token,
 		p_leaderboard_id, p_owner_ids, p_limit, p_cursor, p_expiry)
 
-### <summary>
-### List leaderboard records that belong to a user.
-### </summary>
-### <param name="p_session">The session for the user.</param>
-### <param name="p_leaderboard_id">The ID of the leaderboard to list.</param>
-### <param name="p_owner_id">The ID of the user to list around.</param>
-### <param name="p_expiry">Expiry in seconds (since epoch) to begin fetching records from. Optional. 0 means from current time.</param>
-### <param name="p_limit">The limit of the listings.</param>
-### <returns>A task which resolves to the leaderboard record objects.</returns>
+# List leaderboard records that belong to a user.
+# @param p_session - The session for the user.
+# @param p_leaderboard_id - The ID of the leaderboard to list.
+# @param p_owner_id - The ID of the user to list around.
+# @param p_expiry - Expiry in seconds (since epoch) to begin fetching records from. Optional. 0 means from current time.
+# @param p_limit - The limit of the listings.
+# Returns a task which resolves to the leaderboard record objects.
 func list_leaderboard_records_around_owner_async(p_session : NakamaSession,
 		p_leaderboar_id : String, p_owner_id : String, p_expiry = null, p_limit : int = 1): # -> NakamaAPI.ApiLeaderboardRecordList:
 	return _api_client.list_leaderboard_records_around_owner_async(p_session.token,
 		p_leaderboar_id, p_owner_id, p_limit, p_expiry)
 
-### <summary>
-### Fetch a list of matches active on the server.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_min">The minimum number of match participants.</param>
-### <param name="p_max">The maximum number of match participants.</param>
-### <param name="p_limit">The number of matches to list.</param>
-### <param name="p_authoritative">If authoritative matches should be included.</param>
-### <param name="p_label">The label to filter the match list on.</param>
-### <param name="p_query">A query for the matches to filter.</param>
-### <returns>A task which resolves to the match list object.</returns>
+# Fetch a list of matches active on the server.
+# @param p_session - The session of the user.
+# @param p_min - The minimum number of match participants.
+# @param p_max - The maximum number of match participants.
+# @param p_limit - The number of matches to list.
+# @param p_authoritative - If authoritative matches should be included.
+# @param p_label - The label to filter the match list on.
+# @param p_query - A query for the matches to filter.
+# Returns a task which resolves to the match list object.
 func list_matches_async(p_session : NakamaSession, p_min : int, p_max : int, p_limit : int, p_authoritative : bool,
 		p_label : String, p_query : String): # -> NakamaAPI.ApiMatchList:
 	return _api_client.list_matches_async(p_session.token, p_limit, p_authoritative, p_label, p_min, p_max, p_query)
 
-### <summary>
-### List notifications for the user with an optional cursor.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_limit">The number of notifications to list.</param>
-### <param name="p_cacheable_cursor">A cursor for the current position in notifications to list.</param>
-### <returns>A task to resolve notifications objects.</returns>
+# List notifications for the user with an optional cursor.
+# @param p_session - The session of the user.
+# @param p_limit - The number of notifications to list.
+# @param p_cacheable_cursor - A cursor for the current position in notifications to list.
+# Returns a task to resolve notifications objects.
 func list_notifications_async(p_session : NakamaSession, p_limit : int = 1, p_cacheable_cursor = null): # -> NakamaAPI.ApiNotificationList:
 	return _api_client.list_notifications_async(p_session.token, p_limit, p_cacheable_cursor)
 
-### <summary>
-### List storage objects in a collection which have public read access.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_collection">The collection to list over.</param>
-### <param name="p_user_id">The id of the user that owns the objects.</param>
-### <param name="p_limit">The number of objects to list.</param>
-### <param name="p_cursor">A cursor to paginate over the collection.</param>
-### <returns>A task which resolves to the storage object list.</returns>
-func list_storage_objects_async(p_session : NakamaSession, p_collection : String, p_user_id : String = "", p_limit : int = 1, p_cursor = null): # -> NakamaAPI.ApiStorageObjectList:
-	return _api_client.list_storage_objects_async(p_session.token, p_collection, p_user_id, p_limit, p_cursor)
+# List storage objects in a collection which have public read access.
+# @param p_session - The session of the user.
+# @param p_collection - The collection to list over.
+# @param p_limit - The number of objects to list.
+# @param p_cursor - A cursor to paginate over the collection.
+# Returns a task which resolves to the storage object list.
+func list_storage_objects_async(p_session : NakamaSession, p_collection : String, p_limit : int = 1, p_cursor = null): # -> NakamaAPI.ApiStorageObjectList:
+	return _api_client.list_storage_objects_async(p_session.token, p_collection, "", p_limit, p_cursor)
 
-### <summary>
-### List tournament records around the owner.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_tournament_id">The ID of the tournament.</param>
-### <param name="p_owner_id">The ID of the owner to pivot around.</param>
-### <param name="p_expiry">Expiry in seconds (since epoch) to begin fetching records from.</param>
-### <param name="p_limit">The number of records to list.</param>
-### <returns>A task which resolves to the tournament record list object.</returns>
+# List tournament records around the owner.
+# @param p_session - The session of the user.
+# @param p_tournament_id - The ID of the tournament.
+# @param p_owner_id - The ID of the owner to pivot around.
+# @param p_expiry - Expiry in seconds (since epoch) to begin fetching records from.
+# @param p_limit - The number of records to list.
+# Returns a task which resolves to the tournament record list object.
 func list_tournament_records_around_owner_async(p_session : NakamaSession,
 		p_tournament_id : String, p_owner_id : String, p_expiry = null, p_limit : int = 1): # -> NakamaAPI.ApiTournamentRecordList:
 	return _api_client.list_tournament_records_around_owner_async(p_session.token, p_tournament_id, p_owner_id, p_limit, p_expiry)
 
-### <summary>
-### List records from a tournament.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_tournament_id">The ID of the tournament.</param>
-### <param name="p_owner_ids">The IDs of the record owners to return in the result.</param>
-### <param name="p_expiry">Expiry in seconds (since epoch) to begin fetching records from.</param>
-### <param name="p_limit">The number of records to list.</param>
-### <param name="p_cursor">An optional cursor for the next page of tournament records.</param>
-### <returns>A task which resolves to the list of tournament records.</returns>
+# List records from a tournament.
+# @param p_session - The session of the user.
+# @param p_tournament_id - The ID of the tournament.
+# @param p_owner_ids - The IDs of the record owners to return in the result.
+# @param p_expiry - Expiry in seconds (since epoch) to begin fetching records from.
+# @param p_limit - The number of records to list.
+# @param p_cursor - An optional cursor for the next page of tournament records.
+# Returns a task which resolves to the list of tournament records.
 func list_tournament_records_async(p_session : NakamaSession, p_tournament_id : String,
 		p_owner_ids = null, p_expiry = null, p_limit : int = 1, p_cursor = null): # -> NakamaAPI.ApiTournamentRecordList:
 	return _api_client.list_tournament_records_async(p_session.token, p_tournament_id, p_owner_ids, p_limit, p_cursor, p_expiry)
 
-### <summary>
-### List current or upcoming tournaments.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_category_start">The start of the category of tournaments to include.</param>
-### <param name="p_category_end">The end of the category of tournaments to include.</param>
-### <param name="p_start_time">The start time of the tournaments. (UNIX timestamp)</param>
-### <param name="p_end_time">The end time of the tournaments. (UNIX timestamp)</param>
-### <param name="p_limit">The number of tournaments to list.</param>
-### <param name="p_cursor">An optional cursor for the next page of tournaments.</param>
-### <returns>A task which resolves to the list of tournament objects.</returns>
+# List current or upcoming tournaments.
+# @param p_session - The session of the user.
+# @param p_category_start - The start of the category of tournaments to include.
+# @param p_category_end - The end of the category of tournaments to include.
+# @param p_start_time - The start time of the tournaments. (UNIX timestamp)
+# @param p_end_time - The end time of the tournaments. (UNIX timestamp)
+# @param p_limit - The number of tournaments to list.
+# @param p_cursor - An optional cursor for the next page of tournaments.
+# Returns a task which resolves to the list of tournament objects.
 func list_tournaments_async(p_session : NakamaSession, p_category_start : int, p_category_end : int,
 		p_start_time : int, p_end_time : int, p_limit : int = 1, p_cursor = null): # -> NakamaAPI.ApiTournamentList:
 	return _api_client.list_tournaments_async(p_session.token,
 		p_category_start, p_category_end, p_start_time, p_end_time, p_limit, p_cursor)
 
-### <summary>
-### List of groups the current user is a member of.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_user_id">The ID of the user whose groups to list.</param>
-### <param name="p_state">Filter by group membership state.</param>
-### <param name="p_limit">The number of records to list.</param>
-### <param name="p_cursor">A cursor for the current position in the listing.</param>
-### <returns>A task which resolves to the group list object.</returns>
+# List of groups the current user is a member of.
+# @param p_session - The session of the user.
+# @param p_user_id - The ID of the user whose groups to list.
+# @param p_state - Filter by group membership state.
+# @param p_limit - The number of records to list.
+# @param p_cursor - A cursor for the current position in the listing.
+# Returns a task which resolves to the group list object.
 func list_user_groups_async(p_session : NakamaSession, p_user_id : String, p_state = null, p_limit = null, p_cursor = null): # -> NakamaAPI.ApiUserGroupList:
 	return _api_client.list_user_groups_async(p_session.token, p_user_id, p_limit, p_state, p_cursor)
 
-### <summary>
-### List storage objects in a collection which belong to a specific user and have public read access.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_collection">The collection to list over.</param>
-### <param name="p_user_id">The user ID of the user to list objects for.</param>
-### <param name="p_limit">The number of objects to list.</param>
-### <param name="p_cursor">A cursor to paginate over the collection.</param>
-### <returns>A task which resolves to the storage object list.</returns>
+# List storage objects in a collection which belong to a specific user and have public read access.
+# @param p_session - The session of the user.
+# @param p_collection - The collection to list over.
+# @param p_user_id - The user ID of the user to list objects for.
+# @param p_limit - The number of objects to list.
+# @param p_cursor - A cursor to paginate over the collection.
+# Returns a task which resolves to the storage object list.
 func list_users_storage_objects_async(p_session : NakamaSession,
 		p_collection : String, p_user_id : String, p_limit : int, p_cursor : String): # -> NakamaAPI.ApiStorageObjectList:
 	return _api_client.list_storage_objects2_async(p_session.token, p_collection, p_user_id, p_limit, p_cursor)
 
-### <summary>
-### Promote one or more users in the group.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_group_id">The ID of the group to promote users into.</param>
-### <param name="p_ids">The IDs of the users to promote.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Promote one or more users in the group.
+# @param p_session - The session of the user.
+# @param p_group_id - The ID of the group to promote users into.
+# @param p_ids - The IDs of the users to promote.
+# Returns a task which represents the asynchronous operation.
 func promote_group_users_async(p_session : NakamaSession, p_group_id : String, p_ids : PoolStringArray) -> NakamaAsyncResult:
 	return _api_client.promote_group_users_async(p_session.token, p_group_id, p_ids)
 
-### <summary>
-### Read one or more objects from the storage engine.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_ids">The objects to read.</param>
-### <returns>A task which resolves to the storage batch object.</returns>
-func read_storage_objects_async(p_session : NakamaSession, p_ids : Array): # -> NakamaAPI.ApiStorageObjects:
+# Read one or more objects from the storage engine.
+# @param p_session - The session of the user.
+# @param p_ids - The objects to read.
+# Returns a task which resolves to the storage batch object.
+func read_storage_objects_async(p_session : NakamaSession, p_ids : Array): # -> NakamaAPI.ApiStorageObjectList:
 	var ids = []
 	for id in p_ids:
 		if not id is NakamaStorageObjectId:
@@ -679,86 +568,70 @@ func read_storage_objects_async(p_session : NakamaSession, p_ids : Array): # -> 
 			"object_ids": ids
 		}))
 
-### <summary>
-### Execute a function with an input payload on the server.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_id">The ID of the function to execute on the server.</param>
-### <param name="p_payload">The payload to send with the function call.</param>
-### <returns>A task which resolves to the RPC response.</returns>
+# Execute a function with an input payload on the server.
+# @param p_session - The session of the user.
+# @param p_id - The ID of the function to execute on the server.
+# @param p_payload - The payload to send with the function call.
+# Returns a task which resolves to the RPC response.
 func rpc_async(p_session : NakamaSession, p_id : String, p_payload = null): # -> NakamaAPI.ApiRpc:
 	return _api_client.rpc_func_async(p_session.token, p_id, p_payload)
 
-### <summary>
-### Execute a function on the server without a session.
-### </summary>
-### <remarks>
-### This function is usually used with server side code. DO NOT USE client side.
-### </remarks>
-### <param name="p_http_key">The secure HTTP key used to authenticate.</param>
-### <param name="p_id">The id of the function to execute on the server.</param>
-### <param name="p_payload">A payload to send with the function call.</param>
-### <returns>A task to resolve an RPC response.</returns>
+# Execute a function on the server without a session.
+# This function is usually used with server side code. DO NOT USE client side.
+# @param p_http_key - The secure HTTP key used to authenticate.
+# @param p_id - The id of the function to execute on the server.
+# @param p_payload - A payload to send with the function call.
+# Returns a task to resolve an RPC response.
 func rpc_async_with_key(p_http_key : String, p_id : String, p_payload = null): # -> NakamaAPI.ApiRpc:
 	return _api_client.rpc_func2_async("", p_id, p_payload, p_http_key)
 
-### <summary>
-### Unlink a custom ID from the user account owned by the session.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_id">A custom identifier usually obtained from an external authentication service.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Unlink a custom ID from the user account owned by the session.
+# @param p_session - The session of the user.
+# @param p_id - A custom identifier usually obtained from an external authentication service.
+# Returns a task which represents the asynchronous operation.
 func unlink_custom_async(p_session : NakamaSession, p_id : String) -> NakamaAsyncResult:
 	return _api_client.unlink_custom_async(p_session.token, NakamaAPI.ApiAccountCustom.create(NakamaAPI, {
 		"id": p_id
 	}))
 
-### <summary>
-### Unlink a device ID from the user account owned by the session.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_id">A device identifier usually obtained from a platform API.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Unlink a device ID from the user account owned by the session.
+# @param p_session - The session of the user.
+# @param p_id - A device identifier usually obtained from a platform API.
+# Returns a task which represents the asynchronous operation.
 func unlink_device_async(p_session : NakamaSession, p_id : String) -> NakamaAsyncResult:
 	return _api_client.unlink_device_async(p_session.token, NakamaAPI.ApiAccountDevice.create(NakamaAPI, {
 		"id": p_id
 	}))
 
-### <summary>
-### Unlink an email with password from the user account owned by the session.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_email">The email address of the user.</param>
-### <param name="p_password">The password for the user.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Unlink an email with password from the user account owned by the session.
+# @param p_session - The session of the user.
+# @param p_email - The email address of the user.
+# @param p_password - The password for the user.
+# Returns a task which represents the asynchronous operation.
 func unlink_email_async(p_session : NakamaSession, p_email : String, p_password : String) -> NakamaAsyncResult:
 	return _api_client.unlink_email_async(p_session.token, NakamaAPI.ApiAccountEmail.create(NakamaAPI, {
 		"email": p_email,
 		"password": p_password
 	}))
 
-### <summary>
-### Unlink a Facebook profile from the user account owned by the session.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_token">An OAuth access token from the Facebook SDK.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Unlink a Facebook profile from the user account owned by the session.
+# @param p_session - The session of the user.
+# @param p_token - An OAuth access token from the Facebook SDK.
+# Returns a task which represents the asynchronous operation.
 func unlink_facebook_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
 	return _api_client.unlink_facebook_async(p_session.token, NakamaAPI.ApiAccountFacebook.create(NakamaAPI, {
 		"token": p_token
 	}))
 
-### <summary>
-### Unlink a Game Center profile from the user account owned by the session.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_bundle_id">The bundle ID of the Game Center application.</param>
-### <param name="p_player_id">The player ID of the user in Game Center.</param>
-### <param name="p_public_key_url">The URL for the public encryption key.</param>
-### <param name="p_salt">A random <c>NSString</c> used to compute the hash and keep it randomized.</param>
-### <param name="p_signature">The verification signature data generated.</param>
-### <param name="p_timestamp_seconds">The date and time that the signature was created.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Unlink a Game Center profile from the user account owned by the session.
+# @param p_session - The session of the user.
+# @param p_bundle_id - The bundle ID of the Game Center application.
+# @param p_player_id - The player ID of the user in Game Center.
+# @param p_public_key_url - The URL for the public encryption key.
+# @param p_salt - A random `NSString` used to compute the hash and keep it randomized.
+# @param p_signature - The verification signature data generated.
+# @param p_timestamp_seconds - The date and time that the signature was created.
+# Returns a task which represents the asynchronous operation.
 func unlink_game_center_async(p_session : NakamaSession,
 		p_bundle_id : String, p_player_id : String, p_public_key_url : String, p_salt : String, p_signature : String, p_timestamp_seconds) -> NakamaAsyncResult:
 	return _api_client.unlink_game_center_async(p_session.token,
@@ -771,40 +644,34 @@ func unlink_game_center_async(p_session : NakamaSession,
 			"timestamp_seconds": p_timestamp_seconds,
 		}))
 
-### <summary>
-### Unlink a Google profile from the user account owned by the session.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_token">An OAuth access token from the Google SDK.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Unlink a Google profile from the user account owned by the session.
+# @param p_session - The session of the user.
+# @param p_token - An OAuth access token from the Google SDK.
+# Returns a task which represents the asynchronous operation.
 func unlink_google_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
 	return _api_client.unlink_google_async(p_session.token, NakamaAPI.ApiAccountGoogle.create(NakamaAPI, {
 		"token": p_token
 	}))
 
-### <summary>
-### Unlink a Steam profile from the user account owned by the session.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_token">An authentication token from the Steam network.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Unlink a Steam profile from the user account owned by the session.
+# @param p_session - The session of the user.
+# @param p_token - An authentication token from the Steam network.
+# Returns a task which represents the asynchronous operation.
 func unlink_steam_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
 	return _api_client.unlink_steam_async(p_session.token, NakamaAPI.ApiAccountSteam.create(NakamaAPI, {
 		"token": p_token
 	}))
 
-### <summary>
-### Update the current user's account on the server.
-### </summary>
-### <param name="p_session">The session for the user.</param>
-### <param name="p_username">The new username for the user.</param>
-### <param name="p_display_name">A new display name for the user.</param>
-### <param name="p_avatar_url">A new avatar url for the user.</param>
-### <param name="p_lang_tag">A new language tag in BCP-47 format for the user.</param>
-### <param name="p_location">A new location for the user.</param>
-### <param name="p_timezone">New timezone information for the user.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
-func update_account_async(p_session : NakamaSession, p_username = null, p_display_name = null,
+# Update the current user's account on the server.
+# @param p_session - The session for the user.
+# @param p_username - The new username for the user.
+# @param p_display_name - A new display name for the user.
+# @param p_avatar_url - A new avatar url for the user.
+# @param p_lang_tag - A new language tag in BCP-47 format for the user.
+# @param p_location - A new location for the user.
+# @param p_timezone - New timezone information for the user.
+# Returns a task which represents the asynchronous operation.
+func update_account_async(p_session : NakamaSession, p_username : String, p_display_name = null,
 		p_avatar_url = null, p_lang_tag = null, p_location = null, p_timezone = null) -> NakamaAsyncResult:
 	return _api_client.update_account_async(p_session.token,
 		NakamaAPI.ApiUpdateAccountRequest.create(NakamaAPI, {
@@ -816,20 +683,16 @@ func update_account_async(p_session : NakamaSession, p_username = null, p_displa
 			"username": p_username
 		}))
 
-### <summary>
-### Update a group.
-### </summary>
-### <remarks>
-### The user must have the correct access permissions for the group.
-### </remarks>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_group_id">The ID of the group to update.</param>
-### <param name="p_name">A new name for the group.</param>
-### <param name="p_open">If the group should have open membership.</param>
-### <param name="p_description">A new description for the group.</param>
-### <param name="p_avatar_url">A new avatar url for the group.</param>
-### <param name="p_lang_tag">A new language tag in BCP-47 format for the group.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Update a group.
+# The user must have the correct access permissions for the group.
+# @param p_session - The session of the user.
+# @param p_group_id - The ID of the group to update.
+# @param p_name - A new name for the group.
+# @param p_open - If the group should have open membership.
+# @param p_description - A new description for the group.
+# @param p_avatar_url - A new avatar url for the group.
+# @param p_lang_tag - A new language tag in BCP-47 format for the group.
+# Returns a task which represents the asynchronous operation.
 func update_group_async(p_session : NakamaSession,
 		p_group_id : String, p_name : String, p_open : bool, p_description = null, p_avatar_url = null, p_lang_tag = null) -> NakamaAsyncResult:
 	return  _api_client.update_group_async(p_session.token, p_group_id,
@@ -841,15 +704,13 @@ func update_group_async(p_session : NakamaSession,
 			"lang_tag": p_lang_tag
 		}))
 
-### <summary>
-### Write a record to a leaderboard.
-### </summary>
-### <param name="p_session">The session for the user.</param>
-### <param name="p_leaderboard_id">The ID of the leaderboard to write.</param>
-### <param name="p_score">The score for the leaderboard record.</param>
-### <param name="p_subscore">The subscore for the leaderboard record.</param>
-### <param name="p_metadata">The metadata for the leaderboard record.</param>
-### <returns>A task which resolves to the leaderboard record object written.</returns>
+# Write a record to a leaderboard.
+# @param p_session - The session for the user.
+# @param p_leaderboard_id - The ID of the leaderboard to write.
+# @param p_score - The score for the leaderboard record.
+# @param p_subscore - The subscore for the leaderboard record.
+# @param p_metadata - The metadata for the leaderboard record.
+# Returns a task which resolves to the leaderboard record object written.
 func write_leaderboard_record_async(p_session : NakamaSession,
 		p_leaderboard_id : String, p_score : int, p_subscore : int = 0, p_metadata = null): # -> NakamaAPI.ApiLeaderboardRecord:
 	return _api_client.write_leaderboard_record_async(p_session.token, p_leaderboard_id,
@@ -859,12 +720,10 @@ func write_leaderboard_record_async(p_session : NakamaSession,
 			"subscore": str(p_subscore)
 		}))
 
-### <summary>
-### Write objects to the storage engine.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_objects">The objects to write.</param>
-### <returns>A task which resolves to the storage write acknowledgements.</returns>
+# Write objects to the storage engine.
+# @param p_session - The session of the user.
+# @param p_objects - The objects to write.
+# Returns a task which resolves to the storage write acknowledgements.
 func write_storage_objects_async(p_session : NakamaSession, p_objects : Array): # -> NakamaAPI.ApiStorageObjectAcks:
 	var writes : Array = []
 	for obj in p_objects:
@@ -877,15 +736,13 @@ func write_storage_objects_async(p_session : NakamaSession, p_objects : Array): 
 			"objects": writes
 		}))
 
-### <summary>
-### Write a record to a tournament.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_tournament_id">The ID of the tournament to write.</param>
-### <param name="p_score">The score of the tournament record.</param>
-### <param name="p_subscore">The subscore for the tournament record.</param>
-### <param name="p_metadata">The metadata for the tournament record.</param>
-### <returns>A task which resolves to the tournament record object written.</returns>
+# Write a record to a tournament.
+# @param p_session - The session of the user.
+# @param p_tournament_id - The ID of the tournament to write.
+# @param p_score - The score of the tournament record.
+# @param p_subscore - The subscore for the tournament record.
+# @param p_metadata - The metadata for the tournament record.
+# Returns a task which resolves to the tournament record object written.
 func write_tournament_record_async(p_session : NakamaSession,
 		p_tournament_id : String, p_score : int, p_subscore : int = 0, p_metadata = null): # -> NakamaAPI.ApiLeaderboardRecord:
 	return _api_client.write_tournament_record_async(p_session.token, p_tournament_id,

--- a/addons/com.heroiclabs.nakama/client/NakamaClient.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaClient.gd
@@ -133,6 +133,20 @@ func authenticate_facebook_async(p_token : String, p_username = null, p_create :
 			"vars": p_vars
 		}), p_create, p_username, p_import), "completed"))
 
+# Authenticate a user with a Facebook Instant Game token against the server.
+# @param p_signed_player_info - Facebook Instant Game signed info from Facebook SDK.
+# @param p_username - A username used to create the user. May be `null`.
+# @param p_create - If the user should be created when authenticated.
+# @param p_import - If the Facebook friends should be imported.
+# @param p_vars - Extra information that will be bundled in the session token.
+# Returns a task which resolves to a session object.
+func authenticate_facebook_instant_game_async(p_signed_player_info : String, p_username = null, p_create : bool = true, p_import : bool = true, p_vars = null) -> NakamaSession:
+		return _parse_auth(yield(_api_client.authenticate_facebook_instant_game_async(server_key, "",
+				NakamaAPI.ApiAccountFacebookInstantGame.create(NakamaAPI, {
+						"signed_player_info": p_signed_player_info,
+						"vars": p_vars
+				}), p_create, p_username, p_import), "completed"))
+
 # Authenticate a user with Apple Game Center.
 # @param p_bundle_id - The bundle id of the Game Center application.
 # @param p_player_id - The player id of the user in Game Center.
@@ -352,6 +366,20 @@ func link_facebook_async(p_session : NakamaSession, p_token : String) -> NakamaA
 	return _api_client.link_facebook_async(p_session.token, NakamaAPI.ApiAccountFacebook.create(NakamaAPI, {
 		"token": p_token
 	}))
+
+# Add Facebook Instant Game to the social profiles on the current user's account.
+# @param p_session - The session of the user.
+# @param p_token - An OAuth access token from the Facebook SDK.
+# @param p_import - If the Facebook friends should be imported.
+# Returns a task which represents the asynchronous operation.
+func link_facebook_instant_game_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
+	return _api_client.link_facebook_instant_game_async(
+		p_session.token,
+		NakamaAPI.ApiAccountFacebook.create(
+			NakamaAPI, {
+			"token": p_token
+			})
+		)
 
 # Link a Game Center profile to a user account.
 # @param p_session - The session of the user.
@@ -624,6 +652,16 @@ func unlink_facebook_async(p_session : NakamaSession, p_token : String) -> Nakam
 	return _api_client.unlink_facebook_async(p_session.token, NakamaAPI.ApiAccountFacebook.create(NakamaAPI, {
 		"token": p_token
 	}))
+
+# Unlink a Facebook profile from the user account owned by the session.
+# @param p_session - The session of the user.
+# @param p_token - An OAuth access token from the Facebook SDK.
+# Returns a task which represents the asynchronous operation.
+func unlink_facebook_instant_game_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
+	return _api_client.unlink_facebook_instant_game_async(
+		p_session.token,
+		NakamaAPI.ApiAccountFacebook.create(
+			NakamaAPI, {"token": p_token}))
 
 # Unlink a Game Center profile from the user account owned by the session.
 # @param p_session - The session of the user.

--- a/addons/com.heroiclabs.nakama/client/NakamaClient.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaClient.gd
@@ -711,7 +711,7 @@ func unlink_steam_async(p_session : NakamaSession, p_token : String) -> NakamaAs
 # @param p_location - A new location for the user.
 # @param p_timezone - New timezone information for the user.
 # Returns a task which represents the asynchronous operation.
-func update_account_async(p_session : NakamaSession, p_username : String = null, p_display_name = null,
+func update_account_async(p_session : NakamaSession, p_username = null, p_display_name = null,
 		p_avatar_url = null, p_lang_tag = null, p_location = null, p_timezone = null) -> NakamaAsyncResult:
 	return _api_client.update_account_async(p_session.token,
 		NakamaAPI.ApiUpdateAccountRequest.create(NakamaAPI, {

--- a/addons/com.heroiclabs.nakama/client/NakamaClient.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaClient.gd
@@ -480,11 +480,13 @@ func list_notifications_async(p_session : NakamaSession, p_limit : int = 1, p_ca
 # List storage objects in a collection which have public read access.
 # @param p_session - The session of the user.
 # @param p_collection - The collection to list over.
+# @param p_user_id - The id of the user that owns the objects.
 # @param p_limit - The number of objects to list.
 # @param p_cursor - A cursor to paginate over the collection.
 # Returns a task which resolves to the storage object list.
-func list_storage_objects_async(p_session : NakamaSession, p_collection : String, p_limit : int = 1, p_cursor = null): # -> NakamaAPI.ApiStorageObjectList:
-	return _api_client.list_storage_objects_async(p_session.token, p_collection, "", p_limit, p_cursor)
+func list_storage_objects_async(p_session : NakamaSession, p_collection : String, p_user_id : String = "", p_limit : int = 1, p_cursor = null): # -> NakamaAPI.ApiStorageObjectList:
+# List tournament records around the owner.
+	return _api_client.list_storage_objects_async(p_session.token, p_collection, p_user_id, p_limit, p_cursor)
 
 # List tournament records around the owner.
 # @param p_session - The session of the user.
@@ -556,7 +558,7 @@ func promote_group_users_async(p_session : NakamaSession, p_group_id : String, p
 # @param p_session - The session of the user.
 # @param p_ids - The objects to read.
 # Returns a task which resolves to the storage batch object.
-func read_storage_objects_async(p_session : NakamaSession, p_ids : Array): # -> NakamaAPI.ApiStorageObjectList:
+func read_storage_objects_async(p_session : NakamaSession, p_ids : Array): # -> NakamaAPI.ApiStorageObjects:
 	var ids = []
 	for id in p_ids:
 		if not id is NakamaStorageObjectId:
@@ -671,7 +673,7 @@ func unlink_steam_async(p_session : NakamaSession, p_token : String) -> NakamaAs
 # @param p_location - A new location for the user.
 # @param p_timezone - New timezone information for the user.
 # Returns a task which represents the asynchronous operation.
-func update_account_async(p_session : NakamaSession, p_username : String, p_display_name = null,
+func update_account_async(p_session : NakamaSession, p_username : String = null, p_display_name = null,
 		p_avatar_url = null, p_lang_tag = null, p_location = null, p_timezone = null) -> NakamaAsyncResult:
 	return _api_client.update_account_async(p_session.token,
 		NakamaAPI.ApiUpdateAccountRequest.create(NakamaAPI, {

--- a/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
@@ -1,28 +1,22 @@
 tool
 extends Node
 
-### <summary>
-### An adapter which implements the HTTP protocol.
-### </summary>
+# An adapter which implements the HTTP protocol.
 class_name NakamaHTTPAdapter
 
-### <summary>
-### The logger to use with the adapter.
-### </summary>
+# The logger to use with the adapter.
 var logger : Reference = NakamaLogger.new()
 
 var _pending = {}
 var id : int = 0
 
-### <summary>
-### Send a HTTP request.
-### </summary>
-### <param name="method">HTTP method to use for this request.</param>
-### <param name="uri">The fully qualified URI to use.</param>
-### <param name="headers">Request headers to set.</param>
-### <param name="body">Request content body to set.</param>
-### <param name="timeoutSec">Request timeout.</param>
-### <returns>A task which resolves to the contents of the response.</returns>
+# Send a HTTP request.
+# @param method - HTTP method to use for this request.
+# @param uri - The fully qualified URI to use.
+# @param headers - Request headers to set.
+# @param body - Request content body to set.
+# @param timeoutSec - Request timeout.
+# Returns a task which resolves to the contents of the response.
 func send_async(p_method : String, p_uri : String, p_headers : Dictionary, p_body : PoolByteArray, p_timeout : int = 3):
 	var req = HTTPRequest.new()
 	if OS.get_name() != 'HTML5':

--- a/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
+++ b/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
@@ -1,70 +1,44 @@
 extends Reference
 
-### <summary>
-### A socket to interact with Nakama server.
-### </summary>
+# A socket to interact with Nakama server.
 class_name NakamaSocket
 
 const ChannelType = NakamaRTMessage.ChannelJoin.ChannelType
 
-### <summary>
-### Emitted when a socket is closed.
-### </summary>
+# Emitted when a socket is closed.
 signal closed()
 
-### <summary>
-### Emitted when a socket is connected.
-### </summary>
+# Emitted when a socket is connected.
 signal connected()
 
-### <summary>
-### Emitted when a chat channel message is received
-### </summary>
+# Emitted when a chat channel message is received
 signal received_channel_message(p_channel_message) # ApiChannelMessage
 
-### <summary>
-### Emitted when receiving a presence change for joins and leaves with users in a chat channel.
-### </summary>
+# Emitted when receiving a presence change for joins and leaves with users in a chat channel.
 signal received_channel_presence(p_channel_presence) # ChannelPresenceEvent
 
-### <summary>
-### Emitted when an error occurs on the socket.
-### </summary>
+# Emitted when an error occurs on the socket.
 signal received_error(p_error)
 
-### <summary>
-### Emitted when receiving a matchmaker matched message.
-### </summary>
+# Emitted when receiving a matchmaker matched message.
 signal received_matchmaker_matched(p_matchmaker_matched) # MatchmakerMatched
 
-### <summary>
-### Emitted when receiving a message from a multiplayer match.
-### </summary>
+# Emitted when receiving a message from a multiplayer match.
 signal received_match_state(p_match_state) # MatchData
 
-### <summary>
-### Emitted when receiving a presence change for joins and leaves of users in a multiplayer match.
-### </summary>
+# Emitted when receiving a presence change for joins and leaves of users in a multiplayer match.
 signal received_match_presence(p_match_presence_event) # MatchPresenceEvent
 
-### <summary>
-### Emitted when receiving a notification for the current user.
-### </summary>
+# Emitted when receiving a notification for the current user.
 signal received_notification(p_api_notification) # ApiNotification
 
-### <summary>
-### Emitted when receiving a presence change for when a user updated their online status.
-### </summary>
+# Emitted when receiving a presence change for when a user updated their online status.
 signal received_status_presence(p_status_presence_event) # StatusPresenceEvent
 
-### <summary>
-### Emitted when receiving a presence change for joins and leaves on a realtime stream.
-### </summary>
+# Emitted when receiving a presence change for joins and leaves on a realtime stream.
 signal received_stream_presence(p_stream_presence_event) # StreamPresenceEvent
 
-### <summary>
-### Emitted when receiving a message from a realtime stream.
-### </summary>
+# Emitted when receiving a message from a realtime stream.
 signal received_stream_state(p_stream_state) # StreamState
 
 var _adapter : NakamaSocketAdapter
@@ -259,31 +233,23 @@ func _send_async(p_message, p_parse_type = NakamaAsyncResult, p_ns = NakamaRTAPI
 func _connect_function():
 	return yield() # Manually resumed
 
-### <summary>
-### If the socket is connected.
-### </summary>
+# If the socket is connected.
 func is_connected_to_host():
 	return _adapter.is_connected_to_host()
 
-### <summary>
-### If the socket is connecting.
-### </summary>
+# If the socket is connecting.
 func is_connecting_to_host():
 	return _adapter.is_connecting_to_host()
 
-### <summary>
-### Close the socket connection to the server.
-### </summary>
+# Close the socket connection to the server.
 func close():
 	_adapter.close()
 
-### <summary>
-### Connect to the server.
-### </summary>
-### <param name="p_session">The session of the user.</param>
-### <param name="p_appear_online">If the user who appear online to other users.</param>
-### <param name="p_connect_timeout">The time allowed for the socket connection to be established.</param>
-### <returns>A task to represent the asynchronous operation.</returns>
+# Connect to the server.
+# @param p_session - The session of the user.
+# @param p_appear_online - If the user who appear online to other users.
+# @param p_connect_timeout - The time allowed for the socket connection to be established.
+# Returns a task to represent the asynchronous operation.
 func connect_async(p_session : NakamaSession, p_appear_online : bool = false, p_connect_timeout : int = 3):
 	var uri = "%s/ws?lang=en&status=%s&token=%s" % [_base_uri, str(p_appear_online).to_lower(), p_session.token]
 	logger.debug("Connecting to host: %s" % uri)
@@ -291,15 +257,13 @@ func connect_async(p_session : NakamaSession, p_appear_online : bool = false, p_
 	_conn = _connect_function()
 	return _conn
 
-### <summary>
-### Join the matchmaker pool and search for opponents on the server.
-### </summary>
-### <param name="p_query">The matchmaker query to search for opponents.</param>
-### <param name="p_min_count">The minimum number of players to compete against in a match.</param>
-### <param name="p_max_count">The maximum number of players to compete against in a match.</param>
-### <param name="p_string_properties">A set of key/value properties to provide to searches.</param>
-### <param name="p_numeric_properties">A set of key/value numeric properties to provide to searches.</param>
-### <returns>A task which resolves to a matchmaker ticket object.</returns>
+# Join the matchmaker pool and search for opponents on the server.
+# @param p_query - The matchmaker query to search for opponents.
+# @param p_min_count - The minimum number of players to compete against in a match.
+# @param p_max_count - The maximum number of players to compete against in a match.
+# @param p_string_properties - A set of key/value properties to provide to searches.
+# @param p_numeric_properties - A set of key/value numeric properties to provide to searches.
+# Returns a task which resolves to a matchmaker ticket object.
 func add_matchmaker_async(p_query : String = "*", p_min_count : int = 2, p_max_count : int = 8,
 		p_string_props : Dictionary = {}, p_numeric_props : Dictionary = {}) -> NakamaRTAPI.MatchmakerTicket:
 	return _send_async(
@@ -310,38 +274,32 @@ func add_matchmaker_async(p_query : String = "*", p_min_count : int = 2, p_max_c
 ## <summary>
 ## Create a multiplayer match on the server.
 ## </summary>
-## <returns>A task to represent the asynchronous operation.</returns>
+## Returns a task to represent the asynchronous operation.
 func create_match_async():
 	return _send_async(NakamaRTMessage.MatchCreate.new(), NakamaRTAPI.Match)
 
-### <summary>
-### Subscribe to one or more users for their status updates.
-### </summary>
-### <param name="p_user_ids">The IDs of users.</param>
-### <param name="p_usernames">The usernames of the users.</param>
-### <returns>A task which resolves to the current statuses for the users.</returns>
+# Subscribe to one or more users for their status updates.
+# @param p_user_ids - The IDs of users.
+# @param p_usernames - The usernames of the users.
+# Returns a task which resolves to the current statuses for the users.
 func follow_users_async(p_ids : PoolStringArray, p_usernames : PoolStringArray = []) -> NakamaRTAPI.Status:
 	return _send_async(NakamaRTMessage.StatusFollow.new(p_ids, p_usernames), NakamaRTAPI.Status)
 
-### <summary>
-### Join a chat channel on the server.
-### </summary>
-### <param name="p_target">The target channel to join.</param>
-### <param name="p_type">The type of channel to join.</param>
-### <param name="p_persistence">If chat messages should be stored.</param>
-### <param name="p_hidden">If the current user should be hidden on the channel.</param>
-### <returns>A task which resolves to a chat channel object.</returns>
+# Join a chat channel on the server.
+# @param p_target - The target channel to join.
+# @param p_type - The type of channel to join.
+# @param p_persistence - If chat messages should be stored.
+# @param p_hidden - If the current user should be hidden on the channel.
+# Returns a task which resolves to a chat channel object.
 func join_chat_async(p_target : String, p_type : int, p_persistence : bool = false, p_hidden : bool = false) -> NakamaRTAPI.Channel:
 	return _send_async(
 		NakamaRTMessage.ChannelJoin.new(p_target, p_type, p_persistence, p_hidden),
 		NakamaRTAPI.Channel
 	)
 
-### <summary>
-### Join a multiplayer match with the matchmaker matched object.
-### </summary>
-### <param name="p_matched">A matchmaker matched object.</param>
-### <returns>A task which resolves to a multiplayer match.</returns>
+# Join a multiplayer match with the matchmaker matched object.
+# @param p_matched - A matchmaker matched object.
+# Returns a task which resolves to a multiplayer match.
 func join_matched_async(p_matched):
 	var msg := NakamaRTMessage.MatchJoin.new()
 	if p_matched.match_id:
@@ -350,59 +308,47 @@ func join_matched_async(p_matched):
 		msg.token = p_matched.token
 	return _send_async(msg, NakamaRTAPI.Match)
 
-### <summary>
-### Join a multiplayer match by ID.
-### </summary>
-### <param name="p_match_id">The ID of the match to attempt to join.</param>
-### <param name="p_metadata">An optional set of key-value metadata pairs to be passed to the match handler.</param>
-### <returns>A task which resolves to a multiplayer match.</returns>
+# Join a multiplayer match by ID.
+# @param p_match_id - The ID of the match to attempt to join.
+# @param p_metadata - An optional set of key-value metadata pairs to be passed to the match handler.
+# Returns a task which resolves to a multiplayer match.
 func join_match_async(p_match_id : String, p_metadata = null):
 	var msg := NakamaRTMessage.MatchJoin.new()
 	msg.match_id = p_match_id
 	return _send_async(msg, NakamaRTAPI.Match)
 
-### <summary>
-### Leave a chat channel on the server.
-### </summary>
-#### <param name="p_channel_id">The ID of the chat channel to leave.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Leave a chat channel on the server.
+## @param p_channel_id - The ID of the chat channel to leave.
+# Returns a task which represents the asynchronous operation.
 func leave_chat_async(p_channel_id : String) -> NakamaAsyncResult:
 	return _send_async(NakamaRTMessage.ChannelLeave.new(p_channel_id))
 
-### <summary>
-### Leave a multiplayer match on the server.
-### </summary>
-### <param name="p_match_id">The multiplayer match to leave.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Leave a multiplayer match on the server.
+# @param p_match_id - The multiplayer match to leave.
+# Returns a task which represents the asynchronous operation.
 func leave_match_async(p_match_id : String) -> NakamaAsyncResult:
 	return _send_async(NakamaRTMessage.MatchLeave.new(p_match_id))
 
-### <summary>
-### Remove a chat message from a chat channel on the server.
-### </summary>
-### <param name="p_channel">The chat channel with the message to remove.</param>
-### <param name="p_message_id">The ID of the chat message to remove.</param>
-### <returns>A task which resolves to an acknowledgement of the removed message.</returns>
+# Remove a chat message from a chat channel on the server.
+# @param p_channel - The chat channel with the message to remove.
+# @param p_message_id - The ID of the chat message to remove.
+# Returns a task which resolves to an acknowledgement of the removed message.
 func remove_chat_message_async(p_channel_id : String, p_message_id : String):
 	return _send_async(
 		NakamaRTMessage.ChannelMessageRemove.new(p_channel_id, p_message_id),
 		NakamaRTAPI.ChannelMessageAck
 	)
 
-### <summary>
-### Leave the matchmaker pool with the ticket.
-### </summary>
-### <param name="p_ticket">The ticket returned by the matchmaker on join.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Leave the matchmaker pool with the ticket.
+# @param p_ticket - The ticket returned by the matchmaker on join.
+# Returns a task which represents the asynchronous operation.
 func remove_matchmaker_async(p_ticket : String) -> NakamaAsyncResult:
 	return _send_async(NakamaRTMessage.MatchmakerRemove.new(p_ticket))
 
-### <summary>
-### Execute an RPC function to the server.
-### </summary>
-### <param name="p_func_id">The ID of the function to execute.</param>
-### <param name="p_payload">An (optional) String payload to send to the server.</param>
-### <returns>A task which resolves to the RPC function response object.</returns>
+# Execute an RPC function to the server.
+# @param p_func_id - The ID of the function to execute.
+# @param p_payload - An (optional) String payload to send to the server.
+# Returns a task which resolves to the RPC function response object.
 func rpc_async(p_func_id : String, p_payload = null) -> NakamaAPI.ApiRpc:
 	var payload = p_payload
 	match typeof(p_payload):
@@ -415,17 +361,13 @@ func rpc_async(p_func_id : String, p_payload = null) -> NakamaAPI.ApiRpc:
 		"payload": payload
 	}), NakamaAPI.ApiRpc, NakamaAPI, "rpc", "rpc")
 
-### <summary>
-### Send input to a multiplayer match on the server.
-### </summary>
-### ### <remarks>
-### When no presences are supplied the new match state will be sent to all presences.
-### </remarks>
-### <param name="p_match_id">The ID of the match.</param>
-### <param name="p_op_code">An operation code for the input.</param>
-### <param name="p_data">The input data to send.</param>
-### <param name="p_presences">The presences in the match who should receive the input.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Send input to a multiplayer match on the server.
+# When no presences are supplied the new match state will be sent to all presences.
+# @param p_match_id - The ID of the match.
+# @param p_op_code - An operation code for the input.
+# @param p_data - The input data to send.
+# @param p_presences - The presences in the match who should receive the input.
+# Returns a task which represents the asynchronous operation.
 func send_match_state_async(p_match_id, p_op_code : int, p_data : String, p_presences = null):
 	var req = _send_async(NakamaRTMessage.MatchDataSend.new(
 		p_match_id,
@@ -438,17 +380,13 @@ func send_match_state_async(p_match_id, p_op_code : int, p_data : String, p_pres
 	call_deferred("_survive", req)
 	return req
 
-### <summary>
-### Send input to a multiplayer match on the server.
-### </summary>
-### ### <remarks>
-### When no presences are supplied the new match state will be sent to all presences.
-### </remarks>
-### <param name="p_match_id">The ID of the match.</param>
-### <param name="p_op_code">An operation code for the input.</param>
-### <param name="p_data">The input data to send.</param>
-### <param name="p_presences">The presences in the match who should receive the input.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Send input to a multiplayer match on the server.
+# When no presences are supplied the new match state will be sent to all presences.
+# @param p_match_id - The ID of the match.
+# @param p_op_code - An operation code for the input.
+# @param p_data - The input data to send.
+# @param p_presences - The presences in the match who should receive the input.
+# Returns a task which represents the asynchronous operation.
 func send_match_state_raw_async(p_match_id, p_op_code : int, p_data : PoolByteArray, p_presences = null):
 	var req = _send_async(NakamaRTMessage.MatchDataSend.new(
 		p_match_id,
@@ -461,41 +399,33 @@ func send_match_state_raw_async(p_match_id, p_op_code : int, p_data : PoolByteAr
 	call_deferred("_survive", req)
 	return req
 
-### <summary>
-### Unfollow one or more users from their status updates.
-### </summary>
-### <param name="p_user_ids">An array of user ids to unfollow.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Unfollow one or more users from their status updates.
+# @param p_user_ids - An array of user ids to unfollow.
+# Returns a task which represents the asynchronous operation.
 func unfollow_users_async(p_ids : PoolStringArray):
 	return _send_async(NakamaRTMessage.StatusUnfollow.new(p_ids))
 
-### <summary>
-### Update a chat message on a chat channel in the server.
-### </summary>
-### <param name="p_channel_id">The ID of the chat channel with the message to update.</param>
-### <param name="p_message_id">The ID of the message to update.</param>
-### <param name="p_content">The new contents of the chat message.</param>
-### <returns>A task which resolves to an acknowledgement of the updated message.</returns>
+# Update a chat message on a chat channel in the server.
+# @param p_channel_id - The ID of the chat channel with the message to update.
+# @param p_message_id - The ID of the message to update.
+# @param p_content - The new contents of the chat message.
+# Returns a task which resolves to an acknowledgement of the updated message.
 func update_chat_message_async(p_channel_id : String, p_message_id : String, p_content : Dictionary):
 	return _send_async(
 		NakamaRTMessage.ChannelMessageUpdate.new(p_channel_id, p_message_id, JSON.print(p_content)),
 		NakamaRTAPI.ChannelMessageAck
 	)
 
-### <summary>
-### Update the status for the current user online.
-### </summary>
-### <param name="p_status">The new status for the user.</param>
-### <returns>A task which represents the asynchronous operation.</returns>
+# Update the status for the current user online.
+# @param p_status - The new status for the user.
+# Returns a task which represents the asynchronous operation.
 func update_status_async(p_status : String):
 	return _send_async(NakamaRTMessage.StatusUpdate.new(p_status))
 
-### <summary>
-### Send a chat message to a chat channel on the server.
-### </summary>
-### <param name="p_channel_id">The ID of the chat channel to send onto.</param>
-### <param name="p_content">The contents of the message to send.</param>
-### <returns>A task which resolves to the acknowledgement of the chat message write.</returns>
+# Send a chat message to a chat channel on the server.
+# @param p_channel_id - The ID of the chat channel to send onto.
+# @param p_content - The contents of the message to send.
+# Returns a task which resolves to the acknowledgement of the chat message write.
 func write_chat_message_async(p_channel_id : String, p_content : Dictionary):
 	return _send_async(
 		NakamaRTMessage.ChannelMessageSend.new(p_channel_id, JSON.print(p_content)),

--- a/addons/com.heroiclabs.nakama/socket/NakamaSocketAdapter.gd
+++ b/addons/com.heroiclabs.nakama/socket/NakamaSocketAdapter.gd
@@ -1,9 +1,7 @@
 tool
 extends Node
 
-### <summary>
-### An adapter which implements a socket with a protocol supported by Nakama.
-### </summary>
+# An adapter which implements a socket with a protocol supported by Nakama.
 class_name NakamaSocketAdapter
 
 var _ws := WebSocketClient.new()
@@ -11,49 +9,33 @@ var _timeout : int = 30
 var _start : int = 0
 var logger = NakamaLogger.new()
 
-### <summary>
-### A signal emitted when the socket is connected.
-### </summary>
+# A signal emitted when the socket is connected.
 signal connected()
 
-### <summary>
-### A signal emitted when the socket is disconnected.
-### </summary>
+# A signal emitted when the socket is disconnected.
 signal closed()
 
-### <summary>
-### A signal emitted when the socket has an error when connected.
-### </summary>
+# A signal emitted when the socket has an error when connected.
 signal received_error(p_exception)
 
-### <summary>
-### A signal emitted when the socket receives a message.
-### </summary>
+# A signal emitted when the socket receives a message.
 signal received(p_bytes) # PoolByteArray
 
-### <summary>
-### If the socket is connected.
-### </summary>
+# If the socket is connected.
 func is_connected_to_host():
 	return _ws.get_connection_status() == WebSocketClient.CONNECTION_CONNECTED
 
-### <summary>
-### If the socket is connecting.
-### </summary>
+# If the socket is connecting.
 func is_connecting_to_host():
 	return _ws.get_connection_status() == WebSocketClient.CONNECTION_CONNECTING
 
-### <summary>
-### Close the socket with an asynchronous operation.
-### </summary>
+# Close the socket with an asynchronous operation.
 func close():
 	_ws.disconnect_from_host()
 
-### <summary>
-### Connect to the server with an asynchronous operation.
-### </summary>
-### <param name="p_uri">The URI of the server.</param>
-### <param name="p_timeout">The timeout for the connect attempt on the socket.</param>
+# Connect to the server with an asynchronous operation.
+# @param p_uri - The URI of the server.
+# @param p_timeout - The timeout for the connect attempt on the socket.
 func connect_to_host(p_uri : String, p_timeout : int):
 	_ws.disconnect_from_host()
 	_timeout = p_timeout
@@ -63,11 +45,9 @@ func connect_to_host(p_uri : String, p_timeout : int):
 		logger.debug("Error connecting to host %s" % p_uri)
 		call_deferred("emit_signal", "received_error", err)
 
-### <summary>
-### Send data to the server with an asynchronous operation.
-### </summary>
-### <param name="p_buffer">The buffer with the message to send.</param>
-### <param name="p_reliable">If the message should be sent reliably (will be ignored by some protocols).</param>
+# Send data to the server with an asynchronous operation.
+# @param p_buffer - The buffer with the message to send.
+# @param p_reliable - If the message should be sent reliably (will be ignored by some protocols).
 func send(p_buffer : PoolByteArray, p_reliable : bool = true) -> int:
 	return _ws.get_peer(1).put_packet(p_buffer)
 

--- a/addons/com.heroiclabs.nakama/utils/NakamaException.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaException.gd
@@ -1,9 +1,7 @@
 extends Reference
 
-### <summary>
-### An exception generated during a request.
-### Usually contains at least an error message.
-### </summary>
+# An exception generated during a request.
+# Usually contains at least an error message.
 class_name NakamaException
 
 var status_code : int = -1 setget _no_set

--- a/addons/com.heroiclabs.nakama/utils/NakamaSerializer.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaSerializer.gd
@@ -119,7 +119,7 @@ static func deserialize(p_ns : GDScript, p_cls_name : String, p_dict : Dictionar
 
 
 ###
-### Compatibility with Godot 3.1 which does not expose String.http_escape
+# Compatibility with Godot 3.1 which does not expose String.http_escape
 ###
 const HEX = ["0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F"]
 

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -32,9 +32,7 @@ class_name NakamaAPI
 {{- range $defname, $definition := .Definitions }}
 {{- $classname := $defname | title }}
 
-### <summary>
-### {{ $definition.Description | stripNewlines }}
-### </summary>
+# {{ $definition.Description | stripNewlines }}
 class {{ $classname }} extends NakamaAsyncResult:
 
 	const _SCHEMA = {
@@ -59,9 +57,7 @@ class {{ $classname }} extends NakamaAsyncResult:
         {{- $gdType := godotType $property.Type $property.Ref $property.Items.Type $property.Items.Ref }}
 	{{- $gdDef := $gdType | godotDef }}
 
-	### <summary>
-	### {{ $property.Description }}
-	### </summary>
+	# {{ $property.Description }}
 	var {{ $fieldname }} : {{ $gdType }} setget , _get_{{ $fieldname }}
 	var {{ $_field }} = null
 	func _get_{{ $fieldname }}() -> {{ $gdType }}:
@@ -104,9 +100,7 @@ class {{ $classname }} extends NakamaAsyncResult:
 		return output
     {{- end }}
 
-### <summary>
-### The low level client for the Nakama API.
-### </summary>
+# The low level client for the Nakama API.
 class ApiClient extends Reference:
 
 	var _base_uri : String
@@ -124,9 +118,7 @@ class ApiClient extends Reference:
         {{- range $url, $path := .Paths }}
         {{- range $method, $operation := $path}}
 
-	### <summary>
-	### {{ $operation.Summary | stripNewlines }}
-	### </summary>
+	# {{ $operation.Summary | stripNewlines }}
         {{- if $operation.Responses.Ok.Schema.Ref }}
 	func {{ $operation.OperationId | pascalToSnake }}_async(
         {{- else }}


### PR DESCRIPTION
This PR modifies the doc-comments to allow us to generate a code reference for nakama-godot, using [gdscript docs maker](https://github.com/GDQuest/gdscript-docs-maker).

It changes the doc-comment style from C#-like to GDScript-like, i.e. a plain `# My doc comment`.

Note that I used the latest `apigrpc.swagger.json` file from http://github.com/heroiclabs/nakama to regenerate the GDScript API, so there is one new Facebook-related feature in this commit. Also, there is currently no processing done on a handful of XML tags in the source project, i.e. 

```xml
# Send data to the server with an asynchronous operation.
# <param name="p_buffer">The buffer with the message to send.</param>
# <param name="p_reliable">If the message should be sent reliably (will be ignored by some protocols).</param>
```

This is in part because we don't have a standard yet for GDScript to document parameters. It might be JS-style in the end, i.e. `@param p_buffer - The buffer with the message to send`, or something else.