### PR TITLE
Fix default values, error catching, params order.

### DIFF
--- a/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
@@ -380,7 +380,7 @@ class MatchmakerUser extends NakamaAsyncResult:
 class Status extends NakamaAsyncResult:
 
 	const _SCHEMA = {
-		"users": {"name": "users", "type": TYPE_ARRAY, "required": false, "content": "UserPresence"},
+		"presences": {"name": "presences", "type": TYPE_ARRAY, "required": true, "content": "UserPresence"},
 	}
 
 	# The status events for the users followed.

--- a/addons/com.heroiclabs.nakama/client/NakamaClient.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaClient.gd
@@ -310,7 +310,7 @@ func join_group_async(p_session : NakamaSession, p_group_id : String) -> NakamaA
 # @param p_session - The session of the user.
 # @param p_tournament_id - The ID of the tournament to join.
 # Returns a task which represents the asynchronous operation.
-func JoinTournamentAsync(p_session : NakamaSession, p_tournament_id : String) -> NakamaAsyncResult:
+func join_tournament_async(p_session : NakamaSession, p_tournament_id : String) -> NakamaAsyncResult:
 	return _api_client.join_tournament_async(p_session.token, p_tournament_id)
 
 # Kick one or more users from the group.
@@ -456,7 +456,7 @@ func list_group_users_async(p_session : NakamaSession, p_group_id : String, p_st
 # @param p_limit - The number of groups to list.
 # @param p_cursor - A cursor for the current position in the groups to list.
 # Returns a task to resolve group objects.
-func list_groups_async(p_session : NakamaSession, p_name = null, p_limit : int = 1, p_cursor = null): # -> NakamaAPI.ApiGroupList:
+func list_groups_async(p_session : NakamaSession, p_name = null, p_limit : int = 10, p_cursor = null): # -> NakamaAPI.ApiGroupList:
 	return _api_client.list_groups_async(p_session.token, p_name, p_cursor, p_limit)
 
 # List records from a leaderboard.
@@ -468,7 +468,7 @@ func list_groups_async(p_session : NakamaSession, p_name = null, p_limit : int =
 # @param p_cursor - A cursor for the current position in the leaderboard records to list.
 # Returns a task which resolves to the leaderboard record objects.
 func list_leaderboard_records_async(p_session : NakamaSession,
-		p_leaderboard_id : String, p_owner_ids = null, p_expiry = null, p_limit : int = 1, p_cursor = null): # -> NakamaAPI.ApiLeaderboardRecordList:
+		p_leaderboard_id : String, p_owner_ids = null, p_expiry = null, p_limit : int = 10, p_cursor = null): # -> NakamaAPI.ApiLeaderboardRecordList:
 	return _api_client.list_leaderboard_records_async(p_session.token,
 		p_leaderboard_id, p_owner_ids, p_limit, p_cursor, p_expiry)
 
@@ -480,7 +480,7 @@ func list_leaderboard_records_async(p_session : NakamaSession,
 # @param p_limit - The limit of the listings.
 # Returns a task which resolves to the leaderboard record objects.
 func list_leaderboard_records_around_owner_async(p_session : NakamaSession,
-		p_leaderboar_id : String, p_owner_id : String, p_expiry = null, p_limit : int = 1): # -> NakamaAPI.ApiLeaderboardRecordList:
+		p_leaderboar_id : String, p_owner_id : String, p_expiry = null, p_limit : int = 10): # -> NakamaAPI.ApiLeaderboardRecordList:
 	return _api_client.list_leaderboard_records_around_owner_async(p_session.token,
 		p_leaderboar_id, p_owner_id, p_limit, p_expiry)
 
@@ -502,7 +502,7 @@ func list_matches_async(p_session : NakamaSession, p_min : int, p_max : int, p_l
 # @param p_limit - The number of notifications to list.
 # @param p_cacheable_cursor - A cursor for the current position in notifications to list.
 # Returns a task to resolve notifications objects.
-func list_notifications_async(p_session : NakamaSession, p_limit : int = 1, p_cacheable_cursor = null): # -> NakamaAPI.ApiNotificationList:
+func list_notifications_async(p_session : NakamaSession, p_limit : int = 10, p_cacheable_cursor = null): # -> NakamaAPI.ApiNotificationList:
 	return _api_client.list_notifications_async(p_session.token, p_limit, p_cacheable_cursor)
 
 # List storage objects in a collection which have public read access.
@@ -512,7 +512,7 @@ func list_notifications_async(p_session : NakamaSession, p_limit : int = 1, p_ca
 # @param p_limit - The number of objects to list.
 # @param p_cursor - A cursor to paginate over the collection.
 # Returns a task which resolves to the storage object list.
-func list_storage_objects_async(p_session : NakamaSession, p_collection : String, p_user_id : String = "", p_limit : int = 1, p_cursor = null): # -> NakamaAPI.ApiStorageObjectList:
+func list_storage_objects_async(p_session : NakamaSession, p_collection : String, p_user_id : String = "", p_limit : int = 10, p_cursor = null): # -> NakamaAPI.ApiStorageObjectList:
 # List tournament records around the owner.
 	return _api_client.list_storage_objects_async(p_session.token, p_collection, p_user_id, p_limit, p_cursor)
 
@@ -524,7 +524,7 @@ func list_storage_objects_async(p_session : NakamaSession, p_collection : String
 # @param p_limit - The number of records to list.
 # Returns a task which resolves to the tournament record list object.
 func list_tournament_records_around_owner_async(p_session : NakamaSession,
-		p_tournament_id : String, p_owner_id : String, p_expiry = null, p_limit : int = 1): # -> NakamaAPI.ApiTournamentRecordList:
+		p_tournament_id : String, p_owner_id : String, p_limit : int = 10, p_expiry = null): # -> NakamaAPI.ApiTournamentRecordList:
 	return _api_client.list_tournament_records_around_owner_async(p_session.token, p_tournament_id, p_owner_id, p_limit, p_expiry)
 
 # List records from a tournament.
@@ -536,7 +536,7 @@ func list_tournament_records_around_owner_async(p_session : NakamaSession,
 # @param p_cursor - An optional cursor for the next page of tournament records.
 # Returns a task which resolves to the list of tournament records.
 func list_tournament_records_async(p_session : NakamaSession, p_tournament_id : String,
-		p_owner_ids = null, p_expiry = null, p_limit : int = 1, p_cursor = null): # -> NakamaAPI.ApiTournamentRecordList:
+		p_owner_ids = null, p_limit : int = 10, p_cursor = null, p_expiry = null): # -> NakamaAPI.ApiTournamentRecordList:
 	return _api_client.list_tournament_records_async(p_session.token, p_tournament_id, p_owner_ids, p_limit, p_cursor, p_expiry)
 
 # List current or upcoming tournaments.
@@ -549,7 +549,7 @@ func list_tournament_records_async(p_session : NakamaSession, p_tournament_id : 
 # @param p_cursor - An optional cursor for the next page of tournaments.
 # Returns a task which resolves to the list of tournament objects.
 func list_tournaments_async(p_session : NakamaSession, p_category_start : int, p_category_end : int,
-		p_start_time : int, p_end_time : int, p_limit : int = 1, p_cursor = null): # -> NakamaAPI.ApiTournamentList:
+		p_start_time : int, p_end_time : int, p_limit : int = 10, p_cursor = null): # -> NakamaAPI.ApiTournamentList:
 	return _api_client.list_tournaments_async(p_session.token,
 		p_category_start, p_category_end, p_start_time, p_end_time, p_limit, p_cursor)
 
@@ -603,7 +603,7 @@ func read_storage_objects_async(p_session : NakamaSession, p_ids : Array): # -> 
 # @param p_id - The ID of the function to execute on the server.
 # @param p_payload - The payload to send with the function call.
 # Returns a task which resolves to the RPC response.
-func rpc_async(p_session : NakamaSession, p_id : String, p_payload = null): # -> NakamaAPI.ApiRpc:
+func rpc_async(p_session : NakamaSession, p_id : String, p_payload : String = ""): # -> NakamaAPI.ApiRpc:
 	return _api_client.rpc_func_async(p_session.token, p_id, p_payload)
 
 # Execute a function on the server without a session.
@@ -736,7 +736,7 @@ func update_account_async(p_session : NakamaSession, p_username = null, p_displa
 # @param p_lang_tag - A new language tag in BCP-47 format for the group.
 # Returns a task which represents the asynchronous operation.
 func update_group_async(p_session : NakamaSession,
-		p_group_id : String, p_name : String, p_open : bool, p_description = null, p_avatar_url = null, p_lang_tag = null) -> NakamaAsyncResult:
+		p_group_id : String, p_name = null, p_description = null, p_avatar_url = null, p_lang_tag = null, p_open = null) -> NakamaAsyncResult:
 	return  _api_client.update_group_async(p_session.token, p_group_id,
 		NakamaAPI.ApiUpdateGroupRequest.create(NakamaAPI, {
 			"name": p_name,

--- a/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
@@ -99,9 +99,18 @@ static func _send_async(request : HTTPRequest, p_uri : String, p_headers : PoolS
 		return NakamaException.new("Failed to decode JSON response", response_code)
 
 	if response_code != HTTPClient.RESPONSE_OK:
-		logger.debug("Request %d returned response code: %d, RPC code: %d" % [
-			p_id, response_code, json.result["code"]
+		var error = ""
+		var code = -1
+		if typeof(json.result) == TYPE_DICTIONARY:
+			error = json.result["error"] if "error" in json.result else str(json.result)
+			code = json.result["code"] if "code" in json.result else -1
+		else:
+			error = str(json.result)
+		if typeof(error) == TYPE_DICTIONARY:
+			error = JSON.print(error)
+		logger.debug("Request %d returned response code: %d, RPC code: %d, error: %s" % [
+			p_id, response_code, code, error
 		])
-		return NakamaException.new(json.result["error"], response_code, json.result["code"])
+		return NakamaException.new(error, response_code, code)
 
 	return json.result


### PR DESCRIPTION
client.update_group_async allows updating without name change.

Fix HTTPAdapter _send_async error catching (some times an object, some times a string, some times no error, some times not code).

client.send_rpc_async must have string payload (can be empty).

Fix NakamaRTAPI.Status parsing.

Update list_leaderboard_records_around_owner_async and list_leaderboard_records_async parameter order.

Rename client.JoinTournamentAsync to join_tournament_async.

Fix NakamaClient.send_rpc payload parameter (must be string, can be empty).

Update all p_limit parameters default in NakamaClient to 10.