### PR TITLE
Fix add_matchmaker_async/MatchmakerAdd message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- Fix `add_matchmaker_async` and `MatchmakerAdd` parameter assignment.
+
 ## [2.0.0] - 2020-04-02
 
 ### Added

--- a/addons/com.heroiclabs.nakama/api/NakamaRTMessage.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaRTMessage.gd
@@ -257,6 +257,7 @@ class MatchmakerAdd extends NakamaAsyncResult:
 	func _init(p_query : String = "*", p_min_count : int = 2, p_max_count : int = 8,
 			p_string_props : Dictionary = Dictionary(), p_numeric_props : Dictionary = Dictionary()):
 		query = p_query
+		min_count = p_min_count
 		max_count = p_max_count
 		string_properties = p_string_props
 		numeric_properties = p_numeric_props

--- a/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
+++ b/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
@@ -267,7 +267,7 @@ func connect_async(p_session : NakamaSession, p_appear_online : bool = false, p_
 func add_matchmaker_async(p_query : String = "*", p_min_count : int = 2, p_max_count : int = 8,
 		p_string_props : Dictionary = {}, p_numeric_props : Dictionary = {}) -> NakamaRTAPI.MatchmakerTicket:
 	return _send_async(
-		NakamaRTMessage.MatchmakerAdd.new(p_query, p_max_count, p_min_count, p_string_props, p_numeric_props),
+		NakamaRTMessage.MatchmakerAdd.new(p_query, p_min_count, p_max_count, p_string_props, p_numeric_props),
 		NakamaRTAPI.MatchmakerTicket
 	)
 


### PR DESCRIPTION
Parameters where swapped, min_count was not assigned.

Fixes #33 .
I was surprised I didn't catch it when making the docs (and testing the doc bits).
Turns out we weren't setting the min count at all (which defaulted to 2) and by chance all the examples never ended up having `min_count > max_count`. Anyway, this fixes it, swapping the parameters, and correctly assigning min_count in MatchmakerAdd.