### PR TITLE
Set Log Level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
+- Added a log level parameter to `Nakama.create_client`.
+
 ### Fixed
 
 - Fix `add_matchmaker_async` and `MatchmakerAdd` parameter assignment.
+- Fix `DEFAULT_LOG_LEVEL` in Nakama.gd not doing anything.
 
 ## [2.0.0] - 2020-04-02
 

--- a/addons/com.heroiclabs.nakama/Nakama.gd
+++ b/addons/com.heroiclabs.nakama/Nakama.gd
@@ -16,6 +16,7 @@ const DEFAULT_CLIENT_SCHEME : String = "http"
 # The default protocol scheme for the socket connection.
 const DEFAULT_SOCKET_SCHEME : String = "ws"
 
+# The default log level for the Nakama logger.
 const DEFAULT_LOG_LEVEL = NakamaLogger.LOG_LEVEL.DEBUG
 
 var _http_adapter = null
@@ -40,7 +41,9 @@ func create_client(p_server_key : String,
 		p_host : String = DEFAULT_HOST,
 		p_port : int = DEFAULT_PORT,
 		p_scheme : String = DEFAULT_CLIENT_SCHEME,
-		p_timeout : int = DEFAULT_TIMEOUT) -> NakamaClient:
+		p_timeout : int = DEFAULT_TIMEOUT,
+		p_log_level: int = DEFAULT_LOG_LEVEL) -> NakamaClient:
+	logger._level = p_log_level
 	return NakamaClient.new(get_client_adapter(), p_server_key, p_scheme, p_host, p_port, p_timeout)
 
 func create_socket(p_host : String = DEFAULT_HOST,

--- a/addons/com.heroiclabs.nakama/Nakama.gd
+++ b/addons/com.heroiclabs.nakama/Nakama.gd
@@ -42,7 +42,7 @@ func create_client(p_server_key : String,
 		p_port : int = DEFAULT_PORT,
 		p_scheme : String = DEFAULT_CLIENT_SCHEME,
 		p_timeout : int = DEFAULT_TIMEOUT,
-		p_log_level: int = DEFAULT_LOG_LEVEL) -> NakamaClient:
+		p_log_level : int = DEFAULT_LOG_LEVEL) -> NakamaClient:
 	logger._level = p_log_level
 	return NakamaClient.new(get_client_adapter(), p_server_key, p_scheme, p_host, p_port, p_timeout)
 


### PR DESCRIPTION
Fixes: https://github.com/heroiclabs/nakama-godot/issues/40

Adds log level to create_client function call.

I think to improve the elegance of this further would require deeper changes to how the logger reference is passed around.