### PR TITLE
fix: don't shadow variables in NakamaSerializer.gd

### DIFF
--- a/addons/com.heroiclabs.nakama/utils/NakamaSerializer.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaSerializer.gd
@@ -38,15 +38,15 @@ static func serialize(p_obj : Object) -> Dictionary:
 			TYPE_DICTIONARY: # Maps
 				var dict = {}
 				if content == TYPE_OBJECT: # Map of objects
-					for k in val:
+					for k2 in val:
 						if val_type != TYPE_OBJECT:
 							continue
-						dict[k] = serialize(val)
+						dict[k2] = serialize(val)
 				else: # Map of simple types
-					for k in val:
+					for k2 in val:
 						if val_type != content:
 							continue
-						dict[k] = val
+						dict[k2] = val
 			_:
 				out[k] = val
 	return out
@@ -84,15 +84,15 @@ static func deserialize(p_ns : GDScript, p_cls_name : String, p_dict : Dictionar
 				obj.set(pname, deserialize(p_ns, type, val))
 			elif type_cmp == TYPE_DICTIONARY:
 				var v = {}
-				for k in val:
+				for k2 in val:
 					if typeof(content) == TYPE_STRING:
-						v[k] = deserialize(p_ns, content, val[k])
+						v[k2] = deserialize(p_ns, content, val[k2])
 					elif content == TYPE_INT:
-						v[k] = int(val[k])
+						v[k2] = int(val[k2])
 					elif content == TYPE_BOOL:
-						v[k] = bool(val[k])
+						v[k2] = bool(val[k2])
 					else:
-						v[k] = str(val[k])
+						v[k2] = str(val[k2])
 				obj.set(pname, v)
 			elif type_cmp == TYPE_ARRAY:
 				var v


### PR DESCRIPTION
Godot 3.2.2 (perhaps inadvertantly?) made variable shadowing and error.
This removes all instances of variable shadowing to appease the new
GDScript parser.

fixes #47