### PR TITLE
Don't stop processing messages when the game is paused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 ### Fixed
 - Fix Dictionary serialization (e.g. "NakamaSocket.add_matchmaker_async" "p_string_props").
 - Pass join metadata onwards into match join message.
+- Don't stop processing messages when the game is paused.
 
 ## [2.1.0] - 2020-08-01
 

--- a/addons/com.heroiclabs.nakama/Nakama.gd
+++ b/addons/com.heroiclabs.nakama/Nakama.gd
@@ -22,6 +22,9 @@ const DEFAULT_LOG_LEVEL = NakamaLogger.LOG_LEVEL.DEBUG
 var _http_adapter = null
 var logger = NakamaLogger.new()
 
+func _ready() -> void:
+	Nakama.pause_mode = Node.PAUSE_MODE_PROCESS
+
 func get_client_adapter() -> NakamaHTTPAdapter:
 	if _http_adapter == null:
 		_http_adapter = NakamaHTTPAdapter.new()


### PR DESCRIPTION
Last week, I spent several hours trying to figure out why sometimes my game wasn't getting messages from a `NakamaSocket` and it turned out that incoming messages won't get processed when the game is paused.

This is because `NakamaSocketAdaptor` polls the WebSocket in it's `_process()` method, that will stop running when the game is paused, because of the pause_mode it and its parents use (the default, `Node.PAUSE_MODE_INHERIT`, which inherits the value used by the root of the tree, which is `Node.PAUSE_MODE_STOP`).

This was especially problematic for my game, as it pauses the game as part of starting a new match (so that it can be sure that every client has completely finished loading before it starts trying to synchronize game state). But this could also cause problems where the user paused the game, which would unexpectedly prevent their game from receiving any messages from Nakama.

The change in this PR sets the pause_mode for the top-level `Nakama` node, which will will be inherited by the `NakamaSocketAdaptor` and `NakamaHTTPAdaptor` that are created later as children of this node.