### PR TITLE
Fix Broken Parsing of HTTP Error Messages

### DIFF
--- a/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
@@ -102,7 +102,7 @@ static func _send_async(request : HTTPRequest, p_uri : String, p_headers : PoolS
 		var error = ""
 		var code = -1
 		if typeof(json.result) == TYPE_DICTIONARY:
-			error = json.result["error"] if "error" in json.result else str(json.result)
+			error = json.result["message"] if "message" in json.result else str(json.result)
 			code = json.result["code"] if "code" in json.result else -1
 		else:
 			error = str(json.result)


### PR DESCRIPTION
Fixes a bug in the NakamaException.message field when using Nakama server v3.0.

I think the client sdk might need some kind branch naming system to specify which major version of nakama server it supports.

I made an issue for this bug:

https://github.com/heroiclabs/nakama-godot/issues/67

Which I will copy here:

> When using Nakama Server 2.x, when an invalid request is sent, NakamaException.message will be simply a string containing a user readable error message, eg: "Invalid email address format.".
> 
> However, when using Nakama Server 3.x, the same request will result in a NakamaException containing the string:
> 
> `{code:3, message:Invalid email address format.}`
> 
> This is not valid JSON and is invalid behaviour.



