### PR TITLE
Fix payload being sent wrong for nakama v3 in rpc_async_with_key 

### DIFF
--- a/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
@@ -3982,18 +3982,15 @@ class ApiClient extends Reference:
 		var urlpath : String = "/v2/rpc/{id}"
 		urlpath = urlpath.replace("{id}", NakamaSerializer.escape_http(p_id))
 		var query_params = ""
-		if p_payload != null:
-			query_params += "payload=%s&" % NakamaSerializer.escape_http(p_payload)
 		if p_http_key != null:
 			query_params += "http_key=%s&" % NakamaSerializer.escape_http(p_http_key)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
-		var method = "GET"
+		var method = "POST"
 		var headers = {}
 		if (p_bearer_token):
 			var header = "Bearer %s" % p_bearer_token
 			headers["Authorization"] = header
-
-		var content : PoolByteArray
+		var content : PoolByteArray = JSON.print(p_payload).to_utf8()
 		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
 		if result is NakamaException:
 			return ApiRpc.new(result)


### PR DESCRIPTION
This function was trying to send a GET request with the payload encoded in the query params. In nakama server 3.x, this does not work. [Nakama expects the payload to be sent in the request body.](https://heroiclabs.com/docs/runtime-code-basics/#server-to-server)

It seems as though this client sdk was not updated to work for nakama server 3.0

I suggest that the stakeholders here tag or branch for nakama server 2.x and then we update the master branch for 3.x.

A list of all breaking changes for 3.x would be useful.

The major version of the SDK should work for the same major version of Nakama server.