### PR TITLE
Fix error parsing across Nakama versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - Pass join metadata onwards into match join message.
 - Don't stop processing messages when the game is paused.
 - Fix "rpc_async", "rpc_async_with_key". Now uses GET request only if no payload is passed.
+- Fix client errors parsing in Nakama 3.x
 
 ## [2.1.0] - 2020-08-01
 

--- a/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
@@ -102,7 +102,12 @@ static func _send_async(request : HTTPRequest, p_uri : String, p_headers : PoolS
 		var error = ""
 		var code = -1
 		if typeof(json.result) == TYPE_DICTIONARY:
-			error = json.result["error"] if "error" in json.result else str(json.result)
+			if "message" in json.result:
+				error = json.result["message"]
+			elif "error" in json.result:
+				error = json.result["error"]
+			else:
+				error = str(json.result)
 			code = json.result["code"] if "code" in json.result else -1
 		else:
 			error = str(json.result)


### PR DESCRIPTION
Some 2.x versions only had "error" in the dictionary, recent 2.x versions has both "error" and "message", while 3.x versions only has "message".

Closes #68
Fixes #67