### PR TITLE
NakamaClient now auto-refresh sessions using refresh_token.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - Add purchase validation functions.
 - Add Apple authentication functions.
 - Add "demote_group_users_async" function.
+- A session can be refreshed on demand with "session_refresh_async" method.
+- Session and/or refresh tokens can now be disabled with a client logout.
+- The client now supports session auto-refresh using refresh tokens. This is enabled by default.
 
 ### Fixed
 

--- a/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
@@ -3288,14 +3288,14 @@ class ApiClient extends Reference:
 
 	# A healthcheck which load balancers can use to check the service.
 	func healthcheck_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/healthcheck"
 		var query_params = ""
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3306,14 +3306,14 @@ class ApiClient extends Reference:
 
 	# Fetch the current user's account.
 	func get_account_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 	) -> ApiAccount:
 		var urlpath : String = "/v2/account"
 		var query_params = ""
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3325,7 +3325,7 @@ class ApiClient extends Reference:
 
 	# Update fields in the current user's account.
 	func update_account_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiUpdateAccountRequest
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account"
@@ -3333,7 +3333,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "PUT"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3612,7 +3612,7 @@ class ApiClient extends Reference:
 
 	# Add an Apple ID to the social profiles on the current user's account.
 	func link_apple_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountApple
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/link/apple"
@@ -3620,7 +3620,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3632,7 +3632,7 @@ class ApiClient extends Reference:
 
 	# Add a custom ID to the social profiles on the current user's account.
 	func link_custom_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountCustom
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/link/custom"
@@ -3640,7 +3640,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3652,7 +3652,7 @@ class ApiClient extends Reference:
 
 	# Add a device ID to the social profiles on the current user's account.
 	func link_device_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountDevice
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/link/device"
@@ -3660,7 +3660,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3672,7 +3672,7 @@ class ApiClient extends Reference:
 
 	# Add an email+password to the social profiles on the current user's account.
 	func link_email_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountEmail
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/link/email"
@@ -3680,7 +3680,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3692,7 +3692,7 @@ class ApiClient extends Reference:
 
 	# Add Facebook to the social profiles on the current user's account.
 	func link_facebook_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountFacebook
 		, p_sync = null # : boolean
 	) -> NakamaAsyncResult:
@@ -3703,7 +3703,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3715,7 +3715,7 @@ class ApiClient extends Reference:
 
 	# Add Facebook Instant Game to the social profiles on the current user's account.
 	func link_facebook_instant_game_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountFacebookInstantGame
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/link/facebookinstantgame"
@@ -3723,7 +3723,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3735,7 +3735,7 @@ class ApiClient extends Reference:
 
 	# Add Apple's GameCenter to the social profiles on the current user's account.
 	func link_game_center_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountGameCenter
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/link/gamecenter"
@@ -3743,7 +3743,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3755,7 +3755,7 @@ class ApiClient extends Reference:
 
 	# Add Google to the social profiles on the current user's account.
 	func link_google_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountGoogle
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/link/google"
@@ -3763,7 +3763,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3775,7 +3775,7 @@ class ApiClient extends Reference:
 
 	# Add Steam to the social profiles on the current user's account.
 	func link_steam_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiLinkSteamRequest
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/link/steam"
@@ -3783,7 +3783,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3818,7 +3818,7 @@ class ApiClient extends Reference:
 
 	# Remove the Apple ID from the social profiles on the current user's account.
 	func unlink_apple_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountApple
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/unlink/apple"
@@ -3826,7 +3826,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3838,7 +3838,7 @@ class ApiClient extends Reference:
 
 	# Remove the custom ID from the social profiles on the current user's account.
 	func unlink_custom_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountCustom
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/unlink/custom"
@@ -3846,7 +3846,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3858,7 +3858,7 @@ class ApiClient extends Reference:
 
 	# Remove the device ID from the social profiles on the current user's account.
 	func unlink_device_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountDevice
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/unlink/device"
@@ -3866,7 +3866,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3878,7 +3878,7 @@ class ApiClient extends Reference:
 
 	# Remove the email+password from the social profiles on the current user's account.
 	func unlink_email_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountEmail
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/unlink/email"
@@ -3886,7 +3886,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3898,7 +3898,7 @@ class ApiClient extends Reference:
 
 	# Remove Facebook from the social profiles on the current user's account.
 	func unlink_facebook_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountFacebook
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/unlink/facebook"
@@ -3906,7 +3906,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3918,7 +3918,7 @@ class ApiClient extends Reference:
 
 	# Remove Facebook Instant Game profile from the social profiles on the current user's account.
 	func unlink_facebook_instant_game_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountFacebookInstantGame
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/unlink/facebookinstantgame"
@@ -3926,7 +3926,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3938,7 +3938,7 @@ class ApiClient extends Reference:
 
 	# Remove Apple's GameCenter from the social profiles on the current user's account.
 	func unlink_game_center_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountGameCenter
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/unlink/gamecenter"
@@ -3946,7 +3946,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3958,7 +3958,7 @@ class ApiClient extends Reference:
 
 	# Remove Google from the social profiles on the current user's account.
 	func unlink_google_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountGoogle
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/unlink/google"
@@ -3966,7 +3966,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3978,7 +3978,7 @@ class ApiClient extends Reference:
 
 	# Remove Steam from the social profiles on the current user's account.
 	func unlink_steam_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountSteam
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/account/unlink/steam"
@@ -3986,7 +3986,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -3998,7 +3998,7 @@ class ApiClient extends Reference:
 
 	# List a channel's message history.
 	func list_channel_messages_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_channel_id : String
 		, p_limit = null # : integer
 		, p_forward = null # : boolean
@@ -4016,7 +4016,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4028,7 +4028,7 @@ class ApiClient extends Reference:
 
 	# Submit an event for processing in the server's registered runtime custom events handler.
 	func event_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiEvent
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/event"
@@ -4036,7 +4036,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4048,7 +4048,7 @@ class ApiClient extends Reference:
 
 	# Delete one or more users by ID or username.
 	func delete_friends_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_ids = null # : array
 		, p_usernames = null # : array
 	) -> NakamaAsyncResult:
@@ -4063,7 +4063,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "DELETE"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4074,7 +4074,7 @@ class ApiClient extends Reference:
 
 	# List all friends for the current user.
 	func list_friends_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_limit = null # : integer
 		, p_state = null # : integer
 		, p_cursor = null # : string
@@ -4090,7 +4090,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4102,7 +4102,7 @@ class ApiClient extends Reference:
 
 	# Add friends by ID or username to a user's account.
 	func add_friends_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_ids = null # : array
 		, p_usernames = null # : array
 	) -> NakamaAsyncResult:
@@ -4117,7 +4117,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4128,7 +4128,7 @@ class ApiClient extends Reference:
 
 	# Block one or more users by ID or username.
 	func block_friends_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_ids = null # : array
 		, p_usernames = null # : array
 	) -> NakamaAsyncResult:
@@ -4143,7 +4143,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4154,7 +4154,7 @@ class ApiClient extends Reference:
 
 	# Import Facebook friends and add them to a user's account.
 	func import_facebook_friends_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountFacebook
 		, p_reset = null # : boolean
 	) -> NakamaAsyncResult:
@@ -4165,7 +4165,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4177,7 +4177,7 @@ class ApiClient extends Reference:
 
 	# Import Steam friends and add them to a user's account.
 	func import_steam_friends_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiAccountSteam
 		, p_reset = null # : boolean
 	) -> NakamaAsyncResult:
@@ -4188,7 +4188,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4200,7 +4200,7 @@ class ApiClient extends Reference:
 
 	# List groups based on given filters.
 	func list_groups_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_name = null # : string
 		, p_cursor = null # : string
 		, p_limit = null # : integer
@@ -4225,7 +4225,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4237,7 +4237,7 @@ class ApiClient extends Reference:
 
 	# Create a new group with the current user as the owner.
 	func create_group_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiCreateGroupRequest
 	) -> ApiGroup:
 		var urlpath : String = "/v2/group"
@@ -4245,7 +4245,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4258,7 +4258,7 @@ class ApiClient extends Reference:
 
 	# Delete a group by ID.
 	func delete_group_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_group_id : String
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/group/{groupId}"
@@ -4267,7 +4267,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "DELETE"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4278,7 +4278,7 @@ class ApiClient extends Reference:
 
 	# Update fields in a given group.
 	func update_group_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_group_id : String
 		, p_body : ApiUpdateGroupRequest
 	) -> NakamaAsyncResult:
@@ -4288,7 +4288,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "PUT"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4300,7 +4300,7 @@ class ApiClient extends Reference:
 
 	# Add users to a group.
 	func add_group_users_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_group_id : String
 		, p_user_ids = null # : array
 	) -> NakamaAsyncResult:
@@ -4313,7 +4313,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4324,7 +4324,7 @@ class ApiClient extends Reference:
 
 	# Ban a set of users from a group.
 	func ban_group_users_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_group_id : String
 		, p_user_ids = null # : array
 	) -> NakamaAsyncResult:
@@ -4337,7 +4337,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4348,7 +4348,7 @@ class ApiClient extends Reference:
 
 	# Demote a set of users in a group to the next role down.
 	func demote_group_users_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_group_id : String
 		, p_user_ids : PoolStringArray
 	) -> NakamaAsyncResult:
@@ -4361,7 +4361,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4372,7 +4372,7 @@ class ApiClient extends Reference:
 
 	# Immediately join an open group, or request to join a closed one.
 	func join_group_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_group_id : String
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/group/{groupId}/join"
@@ -4381,7 +4381,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4392,7 +4392,7 @@ class ApiClient extends Reference:
 
 	# Kick a set of users from a group.
 	func kick_group_users_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_group_id : String
 		, p_user_ids = null # : array
 	) -> NakamaAsyncResult:
@@ -4405,7 +4405,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4416,7 +4416,7 @@ class ApiClient extends Reference:
 
 	# Leave a group the user is a member of.
 	func leave_group_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_group_id : String
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/group/{groupId}/leave"
@@ -4425,7 +4425,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4436,7 +4436,7 @@ class ApiClient extends Reference:
 
 	# Promote a set of users in a group to the next role up.
 	func promote_group_users_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_group_id : String
 		, p_user_ids = null # : array
 	) -> NakamaAsyncResult:
@@ -4449,7 +4449,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4460,7 +4460,7 @@ class ApiClient extends Reference:
 
 	# List all users that are part of a group.
 	func list_group_users_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_group_id : String
 		, p_limit = null # : integer
 		, p_state = null # : integer
@@ -4478,7 +4478,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4490,7 +4490,7 @@ class ApiClient extends Reference:
 
 	# Validate Apple IAP Receipt
 	func validate_purchase_apple_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiValidatePurchaseAppleRequest
 	) -> ApiValidatePurchaseResponse:
 		var urlpath : String = "/v2/iap/purchase/apple"
@@ -4498,7 +4498,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4511,7 +4511,7 @@ class ApiClient extends Reference:
 
 	# Validate Google IAP Receipt
 	func validate_purchase_google_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiValidatePurchaseGoogleRequest
 	) -> ApiValidatePurchaseResponse:
 		var urlpath : String = "/v2/iap/purchase/google"
@@ -4519,7 +4519,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4532,7 +4532,7 @@ class ApiClient extends Reference:
 
 	# Validate Huawei IAP Receipt
 	func validate_purchase_huawei_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiValidatePurchaseHuaweiRequest
 	) -> ApiValidatePurchaseResponse:
 		var urlpath : String = "/v2/iap/purchase/huawei"
@@ -4540,7 +4540,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4553,7 +4553,7 @@ class ApiClient extends Reference:
 
 	# Delete a leaderboard record.
 	func delete_leaderboard_record_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_leaderboard_id : String
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/leaderboard/{leaderboardId}"
@@ -4562,7 +4562,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "DELETE"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4573,7 +4573,7 @@ class ApiClient extends Reference:
 
 	# List leaderboard records.
 	func list_leaderboard_records_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_leaderboard_id : String
 		, p_owner_ids = null # : array
 		, p_limit = null # : integer
@@ -4595,7 +4595,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4607,7 +4607,7 @@ class ApiClient extends Reference:
 
 	# Write a record to a leaderboard.
 	func write_leaderboard_record_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_leaderboard_id : String
 		, p_body : WriteLeaderboardRecordRequestLeaderboardRecordWrite
 	) -> ApiLeaderboardRecord:
@@ -4617,7 +4617,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4630,7 +4630,7 @@ class ApiClient extends Reference:
 
 	# List leaderboard records that belong to a user.
 	func list_leaderboard_records_around_owner_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_leaderboard_id : String
 		, p_owner_id : String
 		, p_limit = null # : integer
@@ -4647,7 +4647,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4659,7 +4659,7 @@ class ApiClient extends Reference:
 
 	# Fetch list of running matches.
 	func list_matches_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_limit = null # : integer
 		, p_authoritative = null # : boolean
 		, p_label = null # : string
@@ -4684,7 +4684,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4696,7 +4696,7 @@ class ApiClient extends Reference:
 
 	# Delete one or more notifications for the current user.
 	func delete_notifications_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_ids = null # : array
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/notification"
@@ -4707,7 +4707,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "DELETE"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4718,7 +4718,7 @@ class ApiClient extends Reference:
 
 	# Fetch list of notifications.
 	func list_notifications_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_limit = null # : integer
 		, p_cacheable_cursor = null # : string
 	) -> ApiNotificationList:
@@ -4731,7 +4731,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4798,7 +4798,7 @@ class ApiClient extends Reference:
 
 	# Log out a session, invalidate a refresh token, or log out all sessions/refresh tokens for a user.
 	func session_logout_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiSessionLogoutRequest
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/session/logout"
@@ -4806,7 +4806,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4818,7 +4818,7 @@ class ApiClient extends Reference:
 
 	# Get storage objects.
 	func read_storage_objects_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiReadStorageObjectsRequest
 	) -> ApiStorageObjects:
 		var urlpath : String = "/v2/storage"
@@ -4826,7 +4826,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4839,7 +4839,7 @@ class ApiClient extends Reference:
 
 	# Write objects into the storage engine.
 	func write_storage_objects_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiWriteStorageObjectsRequest
 	) -> ApiStorageObjectAcks:
 		var urlpath : String = "/v2/storage"
@@ -4847,7 +4847,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "PUT"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4860,7 +4860,7 @@ class ApiClient extends Reference:
 
 	# Delete one or more objects by ID or username.
 	func delete_storage_objects_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_body : ApiDeleteStorageObjectsRequest
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/storage/delete"
@@ -4868,7 +4868,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "PUT"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4880,7 +4880,7 @@ class ApiClient extends Reference:
 
 	# List publicly readable storage objects in a given collection.
 	func list_storage_objects_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_collection : String
 		, p_user_id = null # : string
 		, p_limit = null # : integer
@@ -4898,7 +4898,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4910,7 +4910,7 @@ class ApiClient extends Reference:
 
 	# List publicly readable storage objects in a given collection.
 	func list_storage_objects2_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_collection : String
 		, p_user_id : String
 		, p_limit = null # : integer
@@ -4927,7 +4927,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4939,7 +4939,7 @@ class ApiClient extends Reference:
 
 	# List current or upcoming tournaments.
 	func list_tournaments_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_category_start = null # : integer
 		, p_category_end = null # : integer
 		, p_start_time = null # : integer
@@ -4964,7 +4964,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -4976,7 +4976,7 @@ class ApiClient extends Reference:
 
 	# List tournament records.
 	func list_tournament_records_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_tournament_id : String
 		, p_owner_ids = null # : array
 		, p_limit = null # : integer
@@ -4998,7 +4998,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -5010,7 +5010,7 @@ class ApiClient extends Reference:
 
 	# Write a record to a tournament.
 	func write_tournament_record2_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_tournament_id : String
 		, p_body : WriteTournamentRecordRequestTournamentRecordWrite
 	) -> ApiLeaderboardRecord:
@@ -5020,7 +5020,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -5033,7 +5033,7 @@ class ApiClient extends Reference:
 
 	# Write a record to a tournament.
 	func write_tournament_record_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_tournament_id : String
 		, p_body : WriteTournamentRecordRequestTournamentRecordWrite
 	) -> ApiLeaderboardRecord:
@@ -5043,7 +5043,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "PUT"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -5056,7 +5056,7 @@ class ApiClient extends Reference:
 
 	# Attempt to join an open and running tournament.
 	func join_tournament_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_tournament_id : String
 	) -> NakamaAsyncResult:
 		var urlpath : String = "/v2/tournament/{tournamentId}/join"
@@ -5065,7 +5065,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -5076,7 +5076,7 @@ class ApiClient extends Reference:
 
 	# List tournament records for a given owner.
 	func list_tournament_records_around_owner_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_tournament_id : String
 		, p_owner_id : String
 		, p_limit = null # : integer
@@ -5093,7 +5093,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -5105,7 +5105,7 @@ class ApiClient extends Reference:
 
 	# Fetch zero or more users by ID and/or username.
 	func get_users_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_ids = null # : array
 		, p_usernames = null # : array
 		, p_facebook_ids = null # : array
@@ -5124,7 +5124,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
@@ -5136,7 +5136,7 @@ class ApiClient extends Reference:
 
 	# List groups the current user belongs to.
 	func list_user_groups_async(
-		p_bearer_token : String
+		p_session : NakamaSession
 		, p_user_id : String
 		, p_limit = null # : integer
 		, p_state = null # : integer
@@ -5154,7 +5154,7 @@ class ApiClient extends Reference:
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
 
 		var content : PoolByteArray

--- a/addons/com.heroiclabs.nakama/api/NakamaSession.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaSession.gd
@@ -20,6 +20,9 @@ func _no_set(v):
 func is_expired() -> bool:
 	return expire_time < OS.get_unix_time()
 
+func would_expire_in(p_secs : int) -> bool:
+	return expire_time < OS.get_unix_time() + p_secs
+
 func is_refresh_expired() -> bool:
 	return refresh_expire_time < OS.get_unix_time()
 
@@ -28,36 +31,39 @@ func is_valid():
 
 func _init(p_token = null, p_created : bool = false, p_refresh_token = null, p_exception = null).(p_exception):
 	if p_token:
-		var unpacked = _jwt_unpack(p_token)
-		var decoded = {}
-		if not validate_json(unpacked):
-			decoded = parse_json(unpacked)
-			valid = true
-		if typeof(decoded) != TYPE_DICTIONARY:
-			decoded = {}
-		if decoded.empty():
-			valid = false
-			if p_exception == null:
-				_ex = NakamaException.new("Unable to unpack token")
-
-		token = p_token
 		created = p_created
-		create_time = OS.get_unix_time()
-		expire_time = int(decoded.get("exp", 0))
-		username = str(decoded.get("usn", ""))
-		user_id = str(decoded.get("uid", ""))
-		if decoded.has("vrs") and typeof(decoded["vrs"]) == TYPE_DICTIONARY:
-			for k in decoded["vrs"]:
-				vars[k] = decoded["vrs"][k]
+		_parse_token(p_token)
 	if p_refresh_token:
-		var unpacked = _jwt_unpack(p_refresh_token)
-		var decoded = {}
-		if not validate_json(unpacked):
-			decoded = parse_json(unpacked)
-		if typeof(decoded) != TYPE_DICTIONARY:
-			decoded = {}
-		refresh_expire_time = int(decoded.get("exp", 0))
-		refresh_token = p_refresh_token
+		_parse_refresh_token(p_refresh_token)
+
+func refresh(p_session):
+	if p_session.token:
+		_parse_token(p_session.token)
+	if p_session.refresh_token:
+		_parse_refresh_token(p_session.refresh_token)
+
+func _parse_token(p_token):
+	var decoded = _jwt_unpack(p_token)
+	if decoded.empty():
+		valid = false
+		return
+	valid = true
+	token = p_token
+	create_time = OS.get_unix_time()
+	expire_time = int(decoded.get("exp", 0))
+	username = str(decoded.get("usn", ""))
+	user_id = str(decoded.get("uid", ""))
+	vars = {}
+	if decoded.has("vrs") and typeof(decoded["vrs"]) == TYPE_DICTIONARY:
+		for k in decoded["vrs"]:
+			vars[k] = decoded["vrs"][k]
+
+func _parse_refresh_token(p_refresh_token):
+	var decoded = _jwt_unpack(p_refresh_token)
+	if decoded.empty():
+		return
+	refresh_expire_time = int(decoded.get("exp", 0))
+	refresh_token = p_refresh_token
 
 func _to_string():
 	if is_exception():
@@ -65,14 +71,21 @@ func _to_string():
 	return "Session<created=%s, token=%s, create_time=%d, username=%s, user_id=%s, vars=%s, expire_time=%d, refresh_token=%s refresh_expire_time=%d>" % [
 		created, token, create_time, username, user_id, str(vars), expire_time, refresh_token, refresh_expire_time]
 
-func _jwt_unpack(p_token : String) -> String:
+func _jwt_unpack(p_token : String) -> Dictionary:
 	# Hack decode JSON payload from JWT.
 	if p_token.find(".") == -1:
-		return ""
+		_ex = NakamaException.new("Missing payload: %s" % p_token)
+		return {}
 	var payload = p_token.split('.')[1];
 	var pad_length = ceil(payload.length() / 4.0) * 4;
 	# Pad base64
 	for i in range(0, pad_length - payload.length()):
 		payload += "="
 	payload = payload.replace("-", "+").replace("_", "/")
-	return Marshalls.base64_to_utf8(payload)
+	var unpacked = Marshalls.base64_to_utf8(payload)
+	if not validate_json(unpacked):
+		var decoded = parse_json(unpacked)
+		if typeof(decoded) == TYPE_DICTIONARY:
+			return decoded
+	_ex = NakamaException.new("Unable to unpack token: %s" % p_token)
+	return {}

--- a/addons/com.heroiclabs.nakama/api/NakamaSession.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaSession.gd
@@ -62,8 +62,8 @@ func _init(p_token = null, p_created : bool = false, p_refresh_token = null, p_e
 func _to_string():
 	if is_exception():
 		return get_exception()._to_string()
-	return "Session<created=%s, token=%s, create_time=%d, username=%s, user_id=%s, vars=%s, expire_time=%d, refresh_expire_time=%d>" % [
-		created, token, create_time, username, user_id, str(vars), expire_time, refresh_expire_time]
+	return "Session<created=%s, token=%s, create_time=%d, username=%s, user_id=%s, vars=%s, expire_time=%d, refresh_token=%s refresh_expire_time=%d>" % [
+		created, token, create_time, username, user_id, str(vars), expire_time, refresh_token, refresh_expire_time]
 
 func _jwt_unpack(p_token : String) -> String:
 	# Hack decode JSON payload from JWT.

--- a/addons/com.heroiclabs.nakama/client/NakamaClient.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaClient.gd
@@ -68,7 +68,7 @@ func _parse_auth(p_session) -> NakamaSession:
 # @param p_usernames - The usernames of the users to add as friends.
 # Returns a task which represents the asynchronous operation.
 func add_friends_async(p_session : NakamaSession, p_ids = null, p_usernames = null) -> NakamaAsyncResult:
-	return _api_client.add_friends_async(p_session.token, p_ids, p_usernames)
+	return _api_client.add_friends_async(p_session, p_ids, p_usernames)
 
 # Add one or more users to the group.
 # @param p_session - The session of the user.
@@ -76,7 +76,7 @@ func add_friends_async(p_session : NakamaSession, p_ids = null, p_usernames = nu
 # @param p_ids - The ids of the users to add or invite to the group.
 # Returns a task which represents the asynchronous operation.
 func add_group_users_async(p_session : NakamaSession, p_group_id : String, p_ids : PoolStringArray) -> NakamaAsyncResult:
-	return _api_client.add_group_users_async(p_session.token, p_group_id, p_ids);
+	return _api_client.add_group_users_async(p_session, p_group_id, p_ids);
 
 # Authenticate a user with an Apple ID against the server.
 # @param p_username - A username used to create the user.</param>
@@ -215,7 +215,7 @@ func authenticate_steam_async(p_token : String, p_username = null, p_create : bo
 # @param p_usernames - The usernames of the users to block.
 # Returns a task which represents the asynchronous operation.
 func block_friends_async(p_session : NakamaSession, p_ids : PoolStringArray, p_usernames = null) -> NakamaAsyncResult:
-	return _api_client.block_friends_async(p_session.token, p_ids, p_usernames);
+	return _api_client.block_friends_async(p_session, p_ids, p_usernames);
 
 # Create a group.
 # @param p_session - The session of the user.
@@ -228,7 +228,7 @@ func block_friends_async(p_session : NakamaSession, p_ids : PoolStringArray, p_u
 # Returns a task which resolves to a new group object.
 func create_group_async(p_session : NakamaSession, p_name : String, p_description : String = "",
 		p_avatar_url = null, p_lang_tag = null, p_open : bool = true, p_max_count : int = 100): # -> NakamaAPI.ApiGroup:
-	return _api_client.create_group_async(p_session.token,
+	return _api_client.create_group_async(p_session,
 		NakamaAPI.ApiCreateGroupRequest.create(NakamaAPI, {
 			"avatar_url": p_avatar_url,
 			"description": p_description,
@@ -244,28 +244,28 @@ func create_group_async(p_session : NakamaSession, p_name : String, p_descriptio
 # @param p_usernames - The usernames to remove as friends.
 # Returns a task which represents the asynchronous operation.
 func delete_friends_async(p_session : NakamaSession, p_ids : PoolStringArray, p_usernames = null) -> NakamaAsyncResult:
-	return _api_client.delete_friends_async(p_session.token, p_ids, p_usernames)
+	return _api_client.delete_friends_async(p_session, p_ids, p_usernames)
 
 # Delete a group by id.
 # @param p_session - The session of the user.
 # @param p_group_id - The group id to to remove.
 # Returns a task which represents the asynchronous operation.
 func delete_group_async(p_session : NakamaSession, p_group_id : String) -> NakamaAsyncResult:
-	return _api_client.delete_group_async(p_session.token, p_group_id)
+	return _api_client.delete_group_async(p_session, p_group_id)
 
 # Delete a leaderboard record.
 # @param p_session - The session of the user.
 # @param p_leaderboard_id - The id of the leaderboard with the record to be deleted.
 # Returns a task which represents the asynchronous operation.
 func delete_leaderboard_record_async(p_session : NakamaSession, p_leaderboard_id : String) -> NakamaAsyncResult:
-	return _api_client.delete_leaderboard_record_async(p_session.token, p_leaderboard_id)
+	return _api_client.delete_leaderboard_record_async(p_session, p_leaderboard_id)
 
 # Delete one or more notifications by id.
 # @param p_session - The session of the user.
 # @param p_ids - The notification ids to remove.
 # Returns a task which represents the asynchronous operation.
 func delete_notifications_async(p_session : NakamaSession, p_ids : PoolStringArray) -> NakamaAsyncResult:
-	return _api_client.delete_notifications_async(p_session.token, p_ids)
+	return _api_client.delete_notifications_async(p_session, p_ids)
 
 # Delete one or more storage objects.
 # @param p_session - The session of the user.
@@ -278,7 +278,7 @@ func delete_storage_objects_async(p_session : NakamaSession, p_ids : Array) -> N
 			continue # TODO Exceptions
 		var obj_id : NakamaStorageObjectId = id
 		ids.append(obj_id.as_delete().serialize())
-	return _api_client.delete_storage_objects_async(p_session.token,
+	return _api_client.delete_storage_objects_async(p_session,
 		NakamaAPI.ApiDeleteStorageObjectsRequest.create(NakamaAPI, {
 			"object_ids": ids
 		}))
@@ -289,13 +289,13 @@ func delete_storage_objects_async(p_session : NakamaSession, p_ids : Array) -> N
 # @param p_ids - The IDs of the users to demote.
 # Returns a task which represents the asynchronous operation.
 func demote_group_users_async(p_session : NakamaSession, p_group_id : String, p_user_ids : Array):
-		return _api_client.demote_group_users_async(p_session.token, p_group_id, p_user_ids)
+		return _api_client.demote_group_users_async(p_session, p_group_id, p_user_ids)
 
 # Fetch the user account owned by the session.
 # @param p_session - The session of the user.
 # Returns a task which resolves to the account object.
 func get_account_async(p_session : NakamaSession): # -> NakamaAPI.ApiAccount:
-	return _api_client.get_account_async(p_session.token)
+	return _api_client.get_account_async(p_session)
 
 # Fetch one or more users by id, usernames, and Facebook ids.
 # @param p_session - The session of the user.
@@ -304,7 +304,7 @@ func get_account_async(p_session : NakamaSession): # -> NakamaAPI.ApiAccount:
 # @param p_facebook_ids - The facebook IDs of the users to retrieve.
 # Returns a task which resolves to a collection of user objects.
 func get_users_async(p_session : NakamaSession, p_ids : PoolStringArray, p_usernames = null, p_facebook_ids = null): # -> NakamaAPI.ApiUsers:
-	return _api_client.get_users_async(p_session.token, p_ids, p_usernames, p_facebook_ids)
+	return _api_client.get_users_async(p_session, p_ids, p_usernames, p_facebook_ids)
 
 # Import Facebook friends and add them to the user's account.
 # The server will import friends when the user authenticates with Facebook. This function can be used to be
@@ -314,7 +314,7 @@ func get_users_async(p_session : NakamaSession, p_ids : PoolStringArray, p_usern
 # @param p_reset - If the Facebook friend import for the user should be reset.
 # Returns a task which represents the asynchronous operation.
 func import_facebook_friends_async(p_session : NakamaSession, p_token : String, p_reset = null) -> NakamaAsyncResult:
-	return _api_client.import_facebook_friends_async(p_session.token,
+	return _api_client.import_facebook_friends_async(p_session,
 		NakamaAPI.ApiAccountFacebook.create(NakamaAPI, {
 			"token": p_token
 		}), p_reset)
@@ -327,7 +327,7 @@ func import_facebook_friends_async(p_session : NakamaSession, p_token : String, 
 # @param p_reset - If the Steam friend import for the user should be reset.
 # Returns a task which represents the asynchronous operation.
 func import_steam_friends_async(p_session : NakamaSession, p_token : String, p_reset = null):
-	return _api_client.import_steam_friends_async(p_session.token,
+	return _api_client.import_steam_friends_async(p_session,
 		NakamaAPI.ApiAccountSteam.create(NakamaAPI, {
 			"token": p_token
 		}), p_reset)
@@ -337,14 +337,14 @@ func import_steam_friends_async(p_session : NakamaSession, p_token : String, p_r
 # @param p_group_id - The ID of the group to join.
 # Returns a task which represents the asynchronous operation.
 func join_group_async(p_session : NakamaSession, p_group_id : String) -> NakamaAsyncResult:
-	return _api_client.join_group_async(p_session.token, p_group_id)
+	return _api_client.join_group_async(p_session, p_group_id)
 
 # Join a tournament by ID.
 # @param p_session - The session of the user.
 # @param p_tournament_id - The ID of the tournament to join.
 # Returns a task which represents the asynchronous operation.
 func join_tournament_async(p_session : NakamaSession, p_tournament_id : String) -> NakamaAsyncResult:
-	return _api_client.join_tournament_async(p_session.token, p_tournament_id)
+	return _api_client.join_tournament_async(p_session, p_tournament_id)
 
 # Kick one or more users from the group.
 # @param p_session - The session of the user.
@@ -352,21 +352,21 @@ func join_tournament_async(p_session : NakamaSession, p_tournament_id : String) 
 # @param p_ids - The IDs of the users to kick.
 # Returns a task which represents the asynchronous operation.
 func kick_group_users_async(p_session : NakamaSession, p_group_id : String, p_ids : PoolStringArray) -> NakamaAsyncResult:
-	return _api_client.kick_group_users_async(p_session.token, p_group_id, p_ids)
+	return _api_client.kick_group_users_async(p_session, p_group_id, p_ids)
 
 # Leave a group by ID.
 # @param p_session - The session of the user.
 # @param p_group_id - The ID of the group to leave.
 # Returns a task which represents the asynchronous operation.
 func leave_group_async(p_session : NakamaSession, p_group_id : String) -> NakamaAsyncResult:
-	return _api_client.leave_group_async(p_session.token, p_group_id)
+	return _api_client.leave_group_async(p_session, p_group_id)
 
 # Link an Apple ID to the social profiles on the current user's account.
 # @param p_session - The session of the user.
 # @param p_token - The ID token received from Apple to validate.
 # Returns a task which represents the asynchronous operation.
 func link_apple_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
-	return _api_client.link_apple_async(p_session.token, NakamaAPI.ApiAccountApple.create(NakamaAPI, {
+	return _api_client.link_apple_async(p_session, NakamaAPI.ApiAccountApple.create(NakamaAPI, {
 		"token": p_token
 	}))
 
@@ -375,7 +375,7 @@ func link_apple_async(p_session : NakamaSession, p_token : String) -> NakamaAsyn
 # @param p_id - A custom identifier usually obtained from an external authentication service.
 # Returns a task which represents the asynchronous operation.
 func link_custom_async(p_session : NakamaSession, p_id : String) -> NakamaAsyncResult:
-	return _api_client.link_custom_async(p_session.token, NakamaAPI.ApiAccountCustom.create(NakamaAPI, {
+	return _api_client.link_custom_async(p_session, NakamaAPI.ApiAccountCustom.create(NakamaAPI, {
 		"id": p_id
 	}))
 
@@ -384,7 +384,7 @@ func link_custom_async(p_session : NakamaSession, p_id : String) -> NakamaAsyncR
 # @param p_id - A device identifier usually obtained from a platform API.
 # Returns a task which represents the asynchronous operation.
 func link_device_async(p_session : NakamaSession, p_id : String) -> NakamaAsyncResult:
-	return _api_client.link_device_async(p_session.token, NakamaAPI.ApiAccountDevice.create(NakamaAPI, {
+	return _api_client.link_device_async(p_session, NakamaAPI.ApiAccountDevice.create(NakamaAPI, {
 		"id": p_id
 	}))
 
@@ -394,7 +394,7 @@ func link_device_async(p_session : NakamaSession, p_id : String) -> NakamaAsyncR
 # @param p_password - The password for the user.
 # Returns a task which represents the asynchronous operation.
 func link_email_async(p_session : NakamaSession, p_email : String, p_password : String) -> NakamaAsyncResult:
-	return _api_client.link_email_async(p_session.token, NakamaAPI.ApiAccountEmail.create(NakamaAPI, {
+	return _api_client.link_email_async(p_session, NakamaAPI.ApiAccountEmail.create(NakamaAPI, {
 		"email": p_email,
 		"password": p_password
 	}))
@@ -405,7 +405,7 @@ func link_email_async(p_session : NakamaSession, p_email : String, p_password : 
 # @param p_import - If the Facebook friends should be imported.
 # Returns a task which represents the asynchronous operation.
 func link_facebook_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
-	return _api_client.link_facebook_async(p_session.token, NakamaAPI.ApiAccountFacebook.create(NakamaAPI, {
+	return _api_client.link_facebook_async(p_session, NakamaAPI.ApiAccountFacebook.create(NakamaAPI, {
 		"token": p_token
 	}))
 
@@ -416,7 +416,7 @@ func link_facebook_async(p_session : NakamaSession, p_token : String) -> NakamaA
 # Returns a task which represents the asynchronous operation.
 func link_facebook_instant_game_async(p_session : NakamaSession, p_signed_player_info : String) -> NakamaAsyncResult:
 	return _api_client.link_facebook_instant_game_async(
-		p_session.token,
+		p_session,
 		NakamaAPI.ApiAccountFacebookInstantGame.create(
 			NakamaAPI, {
 				"signed_player_info": p_signed_player_info
@@ -434,7 +434,7 @@ func link_facebook_instant_game_async(p_session : NakamaSession, p_signed_player
 # Returns a task which represents the asynchronous operation.
 func link_game_center_async(p_session : NakamaSession,
 		p_bundle_id : String, p_player_id : String, p_public_key_url : String, p_salt : String, p_signature : String, p_timestamp_seconds) -> NakamaAsyncResult:
-	return _api_client.link_game_center_async(p_session.token,
+	return _api_client.link_game_center_async(p_session,
 		NakamaAPI.ApiAccountGameCenter.create(NakamaAPI, {
 			"bundle_id": p_bundle_id,
 			"player_id": p_player_id,
@@ -449,7 +449,7 @@ func link_game_center_async(p_session : NakamaSession,
 # @param p_token - An OAuth access token from the Google SDK.
 # Returns a task which represents the asynchronous operation.
 func link_google_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
-	return _api_client.link_google_async(p_session.token, NakamaAPI.ApiAccountGoogle.create(NakamaAPI, {
+	return _api_client.link_google_async(p_session, NakamaAPI.ApiAccountGoogle.create(NakamaAPI, {
 		"token": p_token
 	}))
 
@@ -458,7 +458,7 @@ func link_google_async(p_session : NakamaSession, p_token : String) -> NakamaAsy
 # @param p_token - An authentication token from the Steam network.
 # Returns a task which represents the asynchronous operation.
 func link_steam_async(p_session : NakamaSession, p_token : String, p_sync : bool = false) -> NakamaAsyncResult:
-	return _api_client.link_steam_async(p_session.token, NakamaAPI.ApiLinkSteamRequest.create(
+	return _api_client.link_steam_async(p_session, NakamaAPI.ApiLinkSteamRequest.create(
 		NakamaAPI,
 		{
 			"account": NakamaAPI.ApiAccountSteam.create(NakamaAPI, {
@@ -478,7 +478,7 @@ func link_steam_async(p_session : NakamaSession, p_token : String, p_sync : bool
 # Returns a task which resolves to the channel message list object.
 func list_channel_messages_async(p_session : NakamaSession, p_channel_id : String, limit : int = 1,
 		forward : bool = true, cursor = null): # -> NakamaAPI.ApiChannelMessageList:
-	return _api_client.list_channel_messages_async(p_session.token, p_channel_id, limit, forward, cursor)
+	return _api_client.list_channel_messages_async(p_session, p_channel_id, limit, forward, cursor)
 
 # List of friends of the current user.
 # @param p_session - The session of the user.
@@ -487,7 +487,7 @@ func list_channel_messages_async(p_session : NakamaSession, p_channel_id : Strin
 # @param p_cursor - A cursor for the current position in the friends list.
 # Returns a task which resolves to the friend objects.
 func list_friends_async(p_session : NakamaSession, p_state = null, p_limit = null, p_cursor = null): # -> NakamaAPI.ApiFriendList:
-	return _api_client.list_friends_async(p_session.token, p_limit, p_state, p_cursor)
+	return _api_client.list_friends_async(p_session, p_limit, p_state, p_cursor)
 
 # List all users part of the group.
 # @param p_session - The session of the user.
@@ -497,7 +497,7 @@ func list_friends_async(p_session : NakamaSession, p_state = null, p_limit = nul
 # @param p_cursor - A cursor for the current position in the group listing.
 # Returns a task which resolves to the group user objects.
 func list_group_users_async(p_session : NakamaSession, p_group_id : String, p_state = null, p_limit = null, p_cursor = null): # -> NakamaAPI.ApiGroupUserList:
-	return _api_client.list_group_users_async(p_session.token, p_group_id, p_limit, p_state, p_cursor)
+	return _api_client.list_group_users_async(p_session, p_group_id, p_limit, p_state, p_cursor)
 
 # List groups on the server.
 # @param p_session - The session of the user.
@@ -509,7 +509,7 @@ func list_group_users_async(p_session : NakamaSession, p_group_id : String, p_st
 # @param p_open - Optional open/closed filter.
 # Returns a task to resolve group objects.
 func list_groups_async(p_session : NakamaSession, p_name = null, p_limit : int = 10, p_cursor = null, p_lang_tag = null, p_members = null, p_open = null): # -> NakamaAPI.ApiGroupList:
-	return _api_client.list_groups_async(p_session.token, p_name, p_cursor, p_limit, p_lang_tag, p_members, p_open)
+	return _api_client.list_groups_async(p_session, p_name, p_cursor, p_limit, p_lang_tag, p_members, p_open)
 
 # List records from a leaderboard.
 # @param p_session - The session of the user.
@@ -521,7 +521,7 @@ func list_groups_async(p_session : NakamaSession, p_name = null, p_limit : int =
 # Returns a task which resolves to the leaderboard record objects.
 func list_leaderboard_records_async(p_session : NakamaSession,
 		p_leaderboard_id : String, p_owner_ids = null, p_expiry = null, p_limit : int = 10, p_cursor = null): # -> NakamaAPI.ApiLeaderboardRecordList:
-	return _api_client.list_leaderboard_records_async(p_session.token,
+	return _api_client.list_leaderboard_records_async(p_session,
 		p_leaderboard_id, p_owner_ids, p_limit, p_cursor, p_expiry)
 
 # List leaderboard records that belong to a user.
@@ -533,7 +533,7 @@ func list_leaderboard_records_async(p_session : NakamaSession,
 # Returns a task which resolves to the leaderboard record objects.
 func list_leaderboard_records_around_owner_async(p_session : NakamaSession,
 		p_leaderboar_id : String, p_owner_id : String, p_expiry = null, p_limit : int = 10): # -> NakamaAPI.ApiLeaderboardRecordList:
-	return _api_client.list_leaderboard_records_around_owner_async(p_session.token,
+	return _api_client.list_leaderboard_records_around_owner_async(p_session,
 		p_leaderboar_id, p_owner_id, p_limit, p_expiry)
 
 # Fetch a list of matches active on the server.
@@ -547,7 +547,7 @@ func list_leaderboard_records_around_owner_async(p_session : NakamaSession,
 # Returns a task which resolves to the match list object.
 func list_matches_async(p_session : NakamaSession, p_min : int, p_max : int, p_limit : int, p_authoritative : bool,
 		p_label : String, p_query : String): # -> NakamaAPI.ApiMatchList:
-	return _api_client.list_matches_async(p_session.token, p_limit, p_authoritative, p_label, p_min, p_max, p_query)
+	return _api_client.list_matches_async(p_session, p_limit, p_authoritative, p_label, p_min, p_max, p_query)
 
 # List notifications for the user with an optional cursor.
 # @param p_session - The session of the user.
@@ -555,7 +555,7 @@ func list_matches_async(p_session : NakamaSession, p_min : int, p_max : int, p_l
 # @param p_cacheable_cursor - A cursor for the current position in notifications to list.
 # Returns a task to resolve notifications objects.
 func list_notifications_async(p_session : NakamaSession, p_limit : int = 10, p_cacheable_cursor = null): # -> NakamaAPI.ApiNotificationList:
-	return _api_client.list_notifications_async(p_session.token, p_limit, p_cacheable_cursor)
+	return _api_client.list_notifications_async(p_session, p_limit, p_cacheable_cursor)
 
 # List storage objects in a collection which have public read access.
 # @param p_session - The session of the user.
@@ -566,7 +566,7 @@ func list_notifications_async(p_session : NakamaSession, p_limit : int = 10, p_c
 # Returns a task which resolves to the storage object list.
 func list_storage_objects_async(p_session : NakamaSession, p_collection : String, p_user_id : String = "", p_limit : int = 10, p_cursor = null): # -> NakamaAPI.ApiStorageObjectList:
 # List tournament records around the owner.
-	return _api_client.list_storage_objects_async(p_session.token, p_collection, p_user_id, p_limit, p_cursor)
+	return _api_client.list_storage_objects_async(p_session, p_collection, p_user_id, p_limit, p_cursor)
 
 # List tournament records around the owner.
 # @param p_session - The session of the user.
@@ -577,7 +577,7 @@ func list_storage_objects_async(p_session : NakamaSession, p_collection : String
 # Returns a task which resolves to the tournament record list object.
 func list_tournament_records_around_owner_async(p_session : NakamaSession,
 		p_tournament_id : String, p_owner_id : String, p_limit : int = 10, p_expiry = null): # -> NakamaAPI.ApiTournamentRecordList:
-	return _api_client.list_tournament_records_around_owner_async(p_session.token, p_tournament_id, p_owner_id, p_limit, p_expiry)
+	return _api_client.list_tournament_records_around_owner_async(p_session, p_tournament_id, p_owner_id, p_limit, p_expiry)
 
 # List records from a tournament.
 # @param p_session - The session of the user.
@@ -589,7 +589,7 @@ func list_tournament_records_around_owner_async(p_session : NakamaSession,
 # Returns a task which resolves to the list of tournament records.
 func list_tournament_records_async(p_session : NakamaSession, p_tournament_id : String,
 		p_owner_ids = null, p_limit : int = 10, p_cursor = null, p_expiry = null): # -> NakamaAPI.ApiTournamentRecordList:
-	return _api_client.list_tournament_records_async(p_session.token, p_tournament_id, p_owner_ids, p_limit, p_cursor, p_expiry)
+	return _api_client.list_tournament_records_async(p_session, p_tournament_id, p_owner_ids, p_limit, p_cursor, p_expiry)
 
 # List current or upcoming tournaments.
 # @param p_session - The session of the user.
@@ -602,7 +602,7 @@ func list_tournament_records_async(p_session : NakamaSession, p_tournament_id : 
 # Returns a task which resolves to the list of tournament objects.
 func list_tournaments_async(p_session : NakamaSession, p_category_start : int, p_category_end : int,
 		p_start_time : int, p_end_time : int, p_limit : int = 10, p_cursor = null): # -> NakamaAPI.ApiTournamentList:
-	return _api_client.list_tournaments_async(p_session.token,
+	return _api_client.list_tournaments_async(p_session,
 		p_category_start, p_category_end, p_start_time, p_end_time, p_limit, p_cursor)
 
 # List of groups the current user is a member of.
@@ -613,7 +613,7 @@ func list_tournaments_async(p_session : NakamaSession, p_category_start : int, p
 # @param p_cursor - A cursor for the current position in the listing.
 # Returns a task which resolves to the group list object.
 func list_user_groups_async(p_session : NakamaSession, p_user_id : String, p_state = null, p_limit = null, p_cursor = null): # -> NakamaAPI.ApiUserGroupList:
-	return _api_client.list_user_groups_async(p_session.token, p_user_id, p_limit, p_state, p_cursor)
+	return _api_client.list_user_groups_async(p_session, p_user_id, p_limit, p_state, p_cursor)
 
 # List storage objects in a collection which belong to a specific user and have public read access.
 # @param p_session - The session of the user.
@@ -624,7 +624,7 @@ func list_user_groups_async(p_session : NakamaSession, p_user_id : String, p_sta
 # Returns a task which resolves to the storage object list.
 func list_users_storage_objects_async(p_session : NakamaSession,
 		p_collection : String, p_user_id : String, p_limit : int, p_cursor : String): # -> NakamaAPI.ApiStorageObjectList:
-	return _api_client.list_storage_objects2_async(p_session.token, p_collection, p_user_id, p_limit, p_cursor)
+	return _api_client.list_storage_objects2_async(p_session, p_collection, p_user_id, p_limit, p_cursor)
 
 # Promote one or more users in the group.
 # @param p_session - The session of the user.
@@ -632,7 +632,7 @@ func list_users_storage_objects_async(p_session : NakamaSession,
 # @param p_ids - The IDs of the users to promote.
 # Returns a task which represents the asynchronous operation.
 func promote_group_users_async(p_session : NakamaSession, p_group_id : String, p_ids : PoolStringArray) -> NakamaAsyncResult:
-	return _api_client.promote_group_users_async(p_session.token, p_group_id, p_ids)
+	return _api_client.promote_group_users_async(p_session, p_group_id, p_ids)
 
 # Read one or more objects from the storage engine.
 # @param p_session - The session of the user.
@@ -645,7 +645,7 @@ func read_storage_objects_async(p_session : NakamaSession, p_ids : Array): # -> 
 			continue # TODO Exceptions
 		var obj_id : NakamaStorageObjectId = id
 		ids.append(obj_id.as_read().serialize())
-	return _api_client.read_storage_objects_async(p_session.token,
+	return _api_client.read_storage_objects_async(p_session,
 		NakamaAPI.ApiReadStorageObjectsRequest.create(NakamaAPI, {
 			"object_ids": ids
 		}))
@@ -698,7 +698,7 @@ func session_refresh_async(p_sesison : NakamaSession, p_vars = null) -> NakamaSe
 # @param p_token - The ID token received from Apple.
 # Returns a task which represents the asynchronous operation.
 func unlink_apple_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
-	return _api_client.unlink_apple_async(p_session.token, NakamaAPI.ApiAccountApple.create(NakamaAPI, {
+	return _api_client.unlink_apple_async(p_session, NakamaAPI.ApiAccountApple.create(NakamaAPI, {
 		"token": p_token
 	}))
 
@@ -707,7 +707,7 @@ func unlink_apple_async(p_session : NakamaSession, p_token : String) -> NakamaAs
 # @param p_id - A custom identifier usually obtained from an external authentication service.
 # Returns a task which represents the asynchronous operation.
 func unlink_custom_async(p_session : NakamaSession, p_id : String) -> NakamaAsyncResult:
-	return _api_client.unlink_custom_async(p_session.token, NakamaAPI.ApiAccountCustom.create(NakamaAPI, {
+	return _api_client.unlink_custom_async(p_session, NakamaAPI.ApiAccountCustom.create(NakamaAPI, {
 		"id": p_id
 	}))
 
@@ -716,7 +716,7 @@ func unlink_custom_async(p_session : NakamaSession, p_id : String) -> NakamaAsyn
 # @param p_id - A device identifier usually obtained from a platform API.
 # Returns a task which represents the asynchronous operation.
 func unlink_device_async(p_session : NakamaSession, p_id : String) -> NakamaAsyncResult:
-	return _api_client.unlink_device_async(p_session.token, NakamaAPI.ApiAccountDevice.create(NakamaAPI, {
+	return _api_client.unlink_device_async(p_session, NakamaAPI.ApiAccountDevice.create(NakamaAPI, {
 		"id": p_id
 	}))
 
@@ -726,7 +726,7 @@ func unlink_device_async(p_session : NakamaSession, p_id : String) -> NakamaAsyn
 # @param p_password - The password for the user.
 # Returns a task which represents the asynchronous operation.
 func unlink_email_async(p_session : NakamaSession, p_email : String, p_password : String) -> NakamaAsyncResult:
-	return _api_client.unlink_email_async(p_session.token, NakamaAPI.ApiAccountEmail.create(NakamaAPI, {
+	return _api_client.unlink_email_async(p_session, NakamaAPI.ApiAccountEmail.create(NakamaAPI, {
 		"email": p_email,
 		"password": p_password
 	}))
@@ -736,7 +736,7 @@ func unlink_email_async(p_session : NakamaSession, p_email : String, p_password 
 # @param p_token - An OAuth access token from the Facebook SDK.
 # Returns a task which represents the asynchronous operation.
 func unlink_facebook_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
-	return _api_client.unlink_facebook_async(p_session.token, NakamaAPI.ApiAccountFacebook.create(NakamaAPI, {
+	return _api_client.unlink_facebook_async(p_session, NakamaAPI.ApiAccountFacebook.create(NakamaAPI, {
 		"token": p_token
 	}))
 
@@ -746,7 +746,7 @@ func unlink_facebook_async(p_session : NakamaSession, p_token : String) -> Nakam
 # Returns a task which represents the asynchronous operation.
 func unlink_facebook_instant_game_async(p_session : NakamaSession, p_signed_player_info : String) -> NakamaAsyncResult:
 	return _api_client.unlink_facebook_instant_game_async(
-		p_session.token,
+		p_session,
 		NakamaAPI.ApiAccountFacebookInstantGame.create(NakamaAPI, {
 			"signed_player_info": p_signed_player_info
 		})
@@ -763,7 +763,7 @@ func unlink_facebook_instant_game_async(p_session : NakamaSession, p_signed_play
 # Returns a task which represents the asynchronous operation.
 func unlink_game_center_async(p_session : NakamaSession,
 		p_bundle_id : String, p_player_id : String, p_public_key_url : String, p_salt : String, p_signature : String, p_timestamp_seconds) -> NakamaAsyncResult:
-	return _api_client.unlink_game_center_async(p_session.token,
+	return _api_client.unlink_game_center_async(p_session,
 		NakamaAPI.ApiAccountGameCenter.create(NakamaAPI, {
 			"bundle_id": p_bundle_id,
 			"player_id": p_player_id,
@@ -778,7 +778,7 @@ func unlink_game_center_async(p_session : NakamaSession,
 # @param p_token - An OAuth access token from the Google SDK.
 # Returns a task which represents the asynchronous operation.
 func unlink_google_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
-	return _api_client.unlink_google_async(p_session.token, NakamaAPI.ApiAccountGoogle.create(NakamaAPI, {
+	return _api_client.unlink_google_async(p_session, NakamaAPI.ApiAccountGoogle.create(NakamaAPI, {
 		"token": p_token
 	}))
 
@@ -787,7 +787,7 @@ func unlink_google_async(p_session : NakamaSession, p_token : String) -> NakamaA
 # @param p_token - An authentication token from the Steam network.
 # Returns a task which represents the asynchronous operation.
 func unlink_steam_async(p_session : NakamaSession, p_token : String) -> NakamaAsyncResult:
-	return _api_client.unlink_steam_async(p_session.token, NakamaAPI.ApiAccountSteam.create(NakamaAPI, {
+	return _api_client.unlink_steam_async(p_session, NakamaAPI.ApiAccountSteam.create(NakamaAPI, {
 		"token": p_token
 	}))
 
@@ -802,7 +802,7 @@ func unlink_steam_async(p_session : NakamaSession, p_token : String) -> NakamaAs
 # Returns a task which represents the asynchronous operation.
 func update_account_async(p_session : NakamaSession, p_username = null, p_display_name = null,
 		p_avatar_url = null, p_lang_tag = null, p_location = null, p_timezone = null) -> NakamaAsyncResult:
-	return _api_client.update_account_async(p_session.token,
+	return _api_client.update_account_async(p_session,
 		NakamaAPI.ApiUpdateAccountRequest.create(NakamaAPI, {
 			"avatar_url": p_avatar_url,
 			"display_name": p_display_name,
@@ -824,7 +824,7 @@ func update_account_async(p_session : NakamaSession, p_username = null, p_displa
 # Returns a task which represents the asynchronous operation.
 func update_group_async(p_session : NakamaSession,
 		p_group_id : String, p_name = null, p_description = null, p_avatar_url = null, p_lang_tag = null, p_open = null) -> NakamaAsyncResult:
-	return  _api_client.update_group_async(p_session.token, p_group_id,
+	return  _api_client.update_group_async(p_session, p_group_id,
 		NakamaAPI.ApiUpdateGroupRequest.create(NakamaAPI, {
 			"name": p_name,
 			"open": p_open,
@@ -838,7 +838,7 @@ func update_group_async(p_session : NakamaSession,
 # @param p_receipt - The purchase receipt to be validated.
 # Returns a task which resolves to the validated list of purchase receipts.
 func validate_purchase_apple_async(p_session : NakamaSession, p_receipt : String): # -> NakamaAPI.ApiValidatePurchaseResponse
-	return _api_client.validate_purchase_apple_async(p_session.token,
+	return _api_client.validate_purchase_apple_async(p_session,
 		NakamaAPI.ApiValidatePurchaseAppleRequest.create(NakamaAPI, {
 			"receipt": p_receipt
 		}))
@@ -848,7 +848,7 @@ func validate_purchase_apple_async(p_session : NakamaSession, p_receipt : String
 # @param p_receipt - The purchase receipt to be validated.
 # Returns a task which resolves to the validated list of purchase receipts.
 func validate_purchase_google_async(p_session : NakamaSession, p_receipt : String): # -> NakamaAPI.ApiValidatePurchaseResponse
-	return _api_client.validate_purchase_google_async(p_session.token,
+	return _api_client.validate_purchase_google_async(p_session,
 		NakamaAPI.ApiValidatePurchaseGoogleRequest.create(NakamaAPI, {
 			"purchase": p_receipt
 		}))
@@ -859,7 +859,7 @@ func validate_purchase_google_async(p_session : NakamaSession, p_receipt : Strin
 # @param p_signature - The signature of the purchase receipt.
 # Returns a task which resolves to the validated list of purchase receipts.
 func validate_purchase_huawei_async(p_session : NakamaSession, p_receipt : String, p_signature : String): # -> NakamaAPI.ApiValidatePurchaseResponse
-	return _api_client.validate_purchase_huawei_async(p_session.token,
+	return _api_client.validate_purchase_huawei_async(p_session,
 		NakamaAPI.ApiValidatePurchaseHuaweiRequest.create(NakamaAPI, {
 			"purchase": p_receipt,
 			"signature": p_signature
@@ -874,7 +874,7 @@ func validate_purchase_huawei_async(p_session : NakamaSession, p_receipt : Strin
 # Returns a task which resolves to the leaderboard record object written.
 func write_leaderboard_record_async(p_session : NakamaSession,
 		p_leaderboard_id : String, p_score : int, p_subscore : int = 0, p_metadata = null): # -> NakamaAPI.ApiLeaderboardRecord:
-	return _api_client.write_leaderboard_record_async(p_session.token, p_leaderboard_id,
+	return _api_client.write_leaderboard_record_async(p_session, p_leaderboard_id,
 		NakamaAPI.WriteLeaderboardRecordRequestLeaderboardRecordWrite.create(NakamaAPI, {
 			"metadata": p_metadata,
 			"score": str(p_score),
@@ -892,7 +892,7 @@ func write_storage_objects_async(p_session : NakamaSession, p_objects : Array): 
 			continue # TODO Exceptions
 		var write_obj : NakamaWriteStorageObject = obj
 		writes.append(write_obj.as_write().serialize())
-	return _api_client.write_storage_objects_async(p_session.token,
+	return _api_client.write_storage_objects_async(p_session,
 		NakamaAPI.ApiWriteStorageObjectsRequest.create(NakamaAPI, {
 			"objects": writes
 		}))
@@ -906,7 +906,7 @@ func write_storage_objects_async(p_session : NakamaSession, p_objects : Array): 
 # Returns a task which resolves to the tournament record object written.
 func write_tournament_record_async(p_session : NakamaSession,
 		p_tournament_id : String, p_score : int, p_subscore : int = 0, p_metadata = null): # -> NakamaAPI.ApiLeaderboardRecord:
-	return _api_client.write_tournament_record_async(p_session.token, p_tournament_id,
+	return _api_client.write_tournament_record_async(p_session, p_tournament_id,
 		NakamaAPI.WriteTournamentRecordRequestTournamentRecordWrite.create(NakamaAPI, {
 			"metadata": p_metadata,
 			"score": str(p_score),
@@ -922,7 +922,7 @@ func write_tournament_record_async(p_session : NakamaSession,
 # Returns a task which resolves to the tournament record object written.
 func write_tournament_record2_async(p_session : NakamaSession,
 		p_tournament_id : String, p_score : int, p_subscore : int = 0, p_metadata = null): # -> NakamaAPI.ApiLeaderboardRecord:
-	return _api_client.write_tournament_record2_async(p_session.token, p_tournament_id,
+	return _api_client.write_tournament_record2_async(p_session, p_tournament_id,
 		NakamaAPI.WriteTournamentRecordRequestTournamentRecordWrite.create(NakamaAPI, {
 			"metadata": p_metadata,
 			"score": str(p_score),

--- a/addons/com.heroiclabs.nakama/client/NakamaClient.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaClient.gd
@@ -28,7 +28,22 @@ var timeout : int
 
 var logger : NakamaLogger = null
 
-var _api_client := NakamaAPI.ApiClient.new("", NakamaAPI, null) setget _no_set, _no_get
+var _api_client : NakamaAPI.ApiClient setget _no_set, _no_get
+
+var auto_refresh : bool = true setget set_auto_refresh, get_auto_refresh
+var auto_refresh_seconds : int = true setget set_auto_refresh_seconds, get_auto_refresh_seconds
+
+func get_auto_refresh():
+	return _api_client.auto_refresh
+
+func set_auto_refresh(p_value):
+	_api_client.auto_refresh = p_value
+
+func get_auto_refresh_seconds():
+	return _api_client.auto_refresh_time
+
+func set_auto_refresh_seconds(p_value):
+	_api_client.auto_refresh_time = p_value
 
 func _init(p_adapter : NakamaHTTPAdapter,
 		p_server_key : String,
@@ -43,7 +58,7 @@ func _init(p_adapter : NakamaHTTPAdapter,
 	port = p_port
 	timeout = p_timeout
 	logger = p_adapter.logger
-	_api_client = NakamaAPI.ApiClient.new(scheme + "://" + host + ":" + str(port), p_adapter, NakamaAPI, p_timeout)
+	_api_client = NakamaAPI.ApiClient.new(scheme + "://" + host + ":" + str(port), p_adapter, NakamaAPI, server_key, p_timeout)
 
 # Restore a session from the auth token.
 # A `null` or empty authentication token will return `null`.

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -151,7 +151,7 @@ class ApiClient extends Reference:
             {{- end }}
         {{- end }}
         {{- else }}
-		p_bearer_token : String
+		p_session : NakamaSession
         {{- end }}
 
         {{- range $parameter := $operation.Parameters }}
@@ -220,7 +220,7 @@ class ApiClient extends Reference:
                 {{- end }}
             {{- end }}
             {{- else }}
-		var header = "Bearer %s" % p_bearer_token
+		var header = "Bearer %s" % p_session.token
 		headers["Authorization"] = header
             {{- end }}
 

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -121,13 +121,25 @@ class ApiClient extends Reference:
 	var _timeout : int
 
 	var _http_adapter
-	var _namespace
+	var _namespace : GDScript
+	var _server_key : String
+	var auto_refresh := true
+	var auto_refresh_time := 300
 
-	func _init(p_base_uri : String, p_http_adapter, p_namespace : GDScript, p_timeout : int = 10):
+	func _init(p_base_uri : String, p_http_adapter, p_namespace : GDScript, p_server_key : String, p_timeout : int = 10):
 		_base_uri = p_base_uri
 		_timeout = p_timeout
 		_http_adapter = p_http_adapter
 		_namespace = p_namespace
+		_server_key = p_server_key
+
+	func _refresh_session(p_session : NakamaSession):
+		if auto_refresh and p_session.is_valid() and p_session.refresh_token and not p_session.is_refresh_expired() and p_session.would_expire_in(auto_refresh_time):
+			var request = ApiSessionRefreshRequest.new()
+			request._token = p_session.refresh_token
+			return yield(session_refresh_async(_server_key, "", request), "completed")
+		return null
+
 
         {{- range $url, $path := .Paths }}
         {{- range $method, $operation := $path}}
@@ -172,6 +184,18 @@ class ApiClient extends Reference:
 	{{- if $operation.Responses.Ok.Schema.Ref }} -> {{ $operation.Responses.Ok.Schema.Ref | cleanRef }}
 	{{- else }} -> NakamaAsyncResult
 	{{- end }}:
+        {{- $classname := "NakamaAsyncResult" }}
+        {{- if $operation.Responses.Ok.Schema.Ref }}
+          {{- $classname = $operation.Responses.Ok.Schema.Ref | cleanRef }}
+        {{- end }}
+        {{- if not $operation.Security }}
+		var should_refresh = _refresh_session(p_session)
+		if should_refresh != null:
+			var session = yield(should_refresh, "completed")
+			if session.is_exception():
+				return {{ $classname }}.new(session.get_exception())
+			p_session.refresh(session)
+        {{- end }}
 		var urlpath : String = "{{- $url }}"
             {{- range $parameter := $operation.Parameters }}
             {{- $camelcase := $parameter.Name | prependParameter }}
@@ -236,17 +260,14 @@ class ApiClient extends Reference:
             {{- end }}
             {{- end }}
 
-            {{- if $operation.Responses.Ok.Schema.Ref }}
-                {{- $classname := $operation.Responses.Ok.Schema.Ref | cleanRef }}
 		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
 		if result is NakamaException:
 			return {{ $classname }}.new(result)
+
+            {{- if $operation.Responses.Ok.Schema.Ref }}
 		var out : {{ $classname }} = NakamaSerializer.deserialize(_namespace, "{{ $classname }}", result)
 		return out
             {{- else }}
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
-		if result is NakamaException:
-			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
             {{- end}}
 {{- end }}


### PR DESCRIPTION
This is enabled by default, but can be turned off via the `client.auto_refresh` option.

The session is refreshed if it would expire in `client.auto_refresh_seconds` seconds (300 = 5min by default).

This PR depends on #73 .