### PR TITLE
Implement automatic client retry with exponential backoff.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - A session can be refreshed on demand with "session_refresh_async" method.
 - Session and/or refresh tokens can now be invalidated with a client logout.
 - The client now supports session auto-refresh using refresh tokens. This is enabled by default.
+- The client now supports auto-retrying failed request due to network error. This is enabled by defulut.
+- The client now support cancelling requests in-flight via "client.cancel_request".
 
 ### Fixed
 

--- a/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
@@ -3285,18 +3285,42 @@ class RpcStatus extends NakamaAsyncResult:
 class ApiClient extends Reference:
 
 	var _base_uri : String
-	var _timeout : int
 
 	var _http_adapter
 	var _namespace : GDScript
 	var _server_key : String
 	var auto_refresh := true
 	var auto_refresh_time := 300
+	var auto_retry : bool setget _set_retry, _get_retry
+	var auto_retry_count : int setget _set_retry_count, _get_retry_count
+	var auto_retry_backoff_base : int setget _set_retry_backoff, _get_retry_backoff
+	var last_cancel_token setget , _get_last_token
+
+	func _set_retry(p_value):
+		_http_adapter.auto_retry = p_value
+
+	func _get_retry():
+		return _http_adapter.auto_retry
+
+	func _set_retry_count(p_value):
+		_http_adapter.auto_retry_count = p_value
+
+	func _get_retry_count():
+		return _http_adapter.auto_retry_count
+
+	func _set_retry_backoff(p_value):
+		_http_adapter.auto_retry_backoff_base = p_value
+
+	func _get_retry_backoff():
+		return _http_adapter.auto_retry_backoff_base
+
+	func _get_last_token():
+		return _http_adapter.get_last_token()
 
 	func _init(p_base_uri : String, p_http_adapter, p_namespace : GDScript, p_server_key : String, p_timeout : int = 10):
 		_base_uri = p_base_uri
-		_timeout = p_timeout
 		_http_adapter = p_http_adapter
+		_http_adapter.timeout = p_timeout
 		_namespace = p_namespace
 		_server_key = p_server_key
 
@@ -3306,6 +3330,10 @@ class ApiClient extends Reference:
 			request._token = p_session.refresh_token
 			return yield(session_refresh_async(_server_key, "", request), "completed")
 		return null
+
+	func cancel_request(p_token):
+		if p_token:
+			_http_adapter.cancel_request(p_token)
 
 	# A healthcheck which load balancers can use to check the service.
 	func healthcheck_async(
@@ -3327,7 +3355,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -3352,7 +3380,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiAccount.new(result)
 		var out : ApiAccount = NakamaSerializer.deserialize(_namespace, "ApiAccount", result)
@@ -3380,7 +3408,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -3409,7 +3437,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiSession.new(result)
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
@@ -3439,7 +3467,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiSession.new(result)
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
@@ -3469,7 +3497,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiSession.new(result)
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
@@ -3499,7 +3527,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiSession.new(result)
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
@@ -3532,7 +3560,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiSession.new(result)
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
@@ -3562,7 +3590,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiSession.new(result)
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
@@ -3592,7 +3620,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiSession.new(result)
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
@@ -3622,7 +3650,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiSession.new(result)
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
@@ -3655,7 +3683,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiSession.new(result)
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
@@ -3683,7 +3711,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -3710,7 +3738,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -3737,7 +3765,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -3764,7 +3792,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -3794,7 +3822,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -3821,7 +3849,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -3848,7 +3876,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -3875,7 +3903,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -3902,7 +3930,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -3925,7 +3953,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiSession.new(result)
 		var out : ApiSession = NakamaSerializer.deserialize(_namespace, "ApiSession", result)
@@ -3953,7 +3981,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -3980,7 +4008,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4007,7 +4035,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4034,7 +4062,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4061,7 +4089,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4088,7 +4116,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4115,7 +4143,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4142,7 +4170,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4169,7 +4197,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4205,7 +4233,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiChannelMessageList.new(result)
 		var out : ApiChannelMessageList = NakamaSerializer.deserialize(_namespace, "ApiChannelMessageList", result)
@@ -4233,7 +4261,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4266,7 +4294,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4300,7 +4328,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiFriendList.new(result)
 		var out : ApiFriendList = NakamaSerializer.deserialize(_namespace, "ApiFriendList", result)
@@ -4334,7 +4362,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4367,7 +4395,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4397,7 +4425,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4427,7 +4455,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4470,7 +4498,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiGroupList.new(result)
 		var out : ApiGroupList = NakamaSerializer.deserialize(_namespace, "ApiGroupList", result)
@@ -4498,7 +4526,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiGroup.new(result)
 		var out : ApiGroup = NakamaSerializer.deserialize(_namespace, "ApiGroup", result)
@@ -4526,7 +4554,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4555,7 +4583,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4586,7 +4614,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4617,7 +4645,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4648,7 +4676,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4675,7 +4703,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4706,7 +4734,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4733,7 +4761,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4764,7 +4792,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4800,7 +4828,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiGroupUserList.new(result)
 		var out : ApiGroupUserList = NakamaSerializer.deserialize(_namespace, "ApiGroupUserList", result)
@@ -4828,7 +4856,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiValidatePurchaseResponse.new(result)
 		var out : ApiValidatePurchaseResponse = NakamaSerializer.deserialize(_namespace, "ApiValidatePurchaseResponse", result)
@@ -4856,7 +4884,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiValidatePurchaseResponse.new(result)
 		var out : ApiValidatePurchaseResponse = NakamaSerializer.deserialize(_namespace, "ApiValidatePurchaseResponse", result)
@@ -4884,7 +4912,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiValidatePurchaseResponse.new(result)
 		var out : ApiValidatePurchaseResponse = NakamaSerializer.deserialize(_namespace, "ApiValidatePurchaseResponse", result)
@@ -4912,7 +4940,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -4952,7 +4980,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiLeaderboardRecordList.new(result)
 		var out : ApiLeaderboardRecordList = NakamaSerializer.deserialize(_namespace, "ApiLeaderboardRecordList", result)
@@ -4982,7 +5010,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiLeaderboardRecord.new(result)
 		var out : ApiLeaderboardRecord = NakamaSerializer.deserialize(_namespace, "ApiLeaderboardRecord", result)
@@ -5018,7 +5046,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiLeaderboardRecordList.new(result)
 		var out : ApiLeaderboardRecordList = NakamaSerializer.deserialize(_namespace, "ApiLeaderboardRecordList", result)
@@ -5062,7 +5090,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiMatchList.new(result)
 		var out : ApiMatchList = NakamaSerializer.deserialize(_namespace, "ApiMatchList", result)
@@ -5092,7 +5120,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -5123,7 +5151,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiNotificationList.new(result)
 		var out : ApiNotificationList = NakamaSerializer.deserialize(_namespace, "ApiNotificationList", result)
@@ -5152,7 +5180,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiRpc.new(result)
 		var out : ApiRpc = NakamaSerializer.deserialize(_namespace, "ApiRpc", result)
@@ -5180,7 +5208,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiRpc.new(result)
 		var out : ApiRpc = NakamaSerializer.deserialize(_namespace, "ApiRpc", result)
@@ -5208,7 +5236,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -5235,7 +5263,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiStorageObjects.new(result)
 		var out : ApiStorageObjects = NakamaSerializer.deserialize(_namespace, "ApiStorageObjects", result)
@@ -5263,7 +5291,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiStorageObjectAcks.new(result)
 		var out : ApiStorageObjectAcks = NakamaSerializer.deserialize(_namespace, "ApiStorageObjectAcks", result)
@@ -5291,7 +5319,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -5327,7 +5355,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiStorageObjectList.new(result)
 		var out : ApiStorageObjectList = NakamaSerializer.deserialize(_namespace, "ApiStorageObjectList", result)
@@ -5363,7 +5391,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiStorageObjectList.new(result)
 		var out : ApiStorageObjectList = NakamaSerializer.deserialize(_namespace, "ApiStorageObjectList", result)
@@ -5407,7 +5435,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiTournamentList.new(result)
 		var out : ApiTournamentList = NakamaSerializer.deserialize(_namespace, "ApiTournamentList", result)
@@ -5448,7 +5476,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiTournamentRecordList.new(result)
 		var out : ApiTournamentRecordList = NakamaSerializer.deserialize(_namespace, "ApiTournamentRecordList", result)
@@ -5478,7 +5506,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiLeaderboardRecord.new(result)
 		var out : ApiLeaderboardRecord = NakamaSerializer.deserialize(_namespace, "ApiLeaderboardRecord", result)
@@ -5508,7 +5536,7 @@ class ApiClient extends Reference:
 		var content : PoolByteArray
 		content = JSON.print(p_body.serialize()).to_utf8()
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiLeaderboardRecord.new(result)
 		var out : ApiLeaderboardRecord = NakamaSerializer.deserialize(_namespace, "ApiLeaderboardRecord", result)
@@ -5536,7 +5564,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return NakamaAsyncResult.new(result)
 		return NakamaAsyncResult.new()
@@ -5571,7 +5599,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiTournamentRecordList.new(result)
 		var out : ApiTournamentRecordList = NakamaSerializer.deserialize(_namespace, "ApiTournamentRecordList", result)
@@ -5609,7 +5637,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiUsers.new(result)
 		var out : ApiUsers = NakamaSerializer.deserialize(_namespace, "ApiUsers", result)
@@ -5646,7 +5674,7 @@ class ApiClient extends Reference:
 
 		var content : PoolByteArray
 
-		var result = yield(_http_adapter.send_async(method, uri, headers, content, _timeout), "completed")
+		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
 			return ApiUserGroupList.new(result)
 		var out : ApiUserGroupList = NakamaSerializer.deserialize(_namespace, "ApiUserGroupList", result)

--- a/addons/com.heroiclabs.nakama/client/NakamaClient.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaClient.gd
@@ -32,6 +32,10 @@ var _api_client : NakamaAPI.ApiClient setget _no_set, _no_get
 
 var auto_refresh : bool = true setget set_auto_refresh, get_auto_refresh
 var auto_refresh_seconds : int = true setget set_auto_refresh_seconds, get_auto_refresh_seconds
+var auto_retry : bool = true setget set_auto_retry, get_auto_retry
+var auto_retry_count setget set_auto_retry_count, get_auto_retry_count
+var auto_retry_backoff_base setget set_auto_retry_backoff_base, get_auto_retry_backoff_base
+var last_cancel_token setget _no_set, get_last_cancel_token
 
 func get_auto_refresh():
 	return _api_client.auto_refresh
@@ -44,6 +48,30 @@ func get_auto_refresh_seconds():
 
 func set_auto_refresh_seconds(p_value):
 	_api_client.auto_refresh_time = p_value
+
+func get_last_cancel_token():
+	return _api_client.last_cancel_token
+
+func get_auto_retry():
+	return _api_client.auto_retry
+
+func set_auto_retry(p_value):
+	_api_client.auto_retry = p_value
+
+func get_auto_retry_count():
+	return _api_client.auto_retry_count
+
+func set_auto_retry_count(p_value):
+	_api_client.auto_retry_count = p_value
+
+func get_auto_retry_backoff_base():
+	return _api_client.auto_retry_backoff_base
+
+func set_auto_retry_backoff_base(p_value):
+	_api_client.auto_retry_backoff_base = p_value
+
+func cancel_request(p_token):
+	_api_client.cancel_request(p_token)
 
 func _init(p_adapter : NakamaHTTPAdapter,
 		p_server_key : String,

--- a/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
@@ -93,7 +93,7 @@ class AsyncRequest:
 
 	func parse_result():
 		if cancelled:
-			return NakamaException.new("Request cancelled")
+			return NakamaException.new("Request cancelled", -1, -1, true)
 		elif result != HTTPRequest.RESULT_SUCCESS:
 			return NakamaException.new("HTTPRequest failed!", result)
 

--- a/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
@@ -7,8 +7,125 @@ class_name NakamaHTTPAdapter
 # The logger to use with the adapter.
 var logger : Reference = NakamaLogger.new()
 
+# The timeout for requests
+var timeout : int = 3
+# If request should be automatically retried when a network error occurs.
+var auto_retry : bool = true
+# The maximum number of time a request will be retried when auto_retry is true
+var auto_retry_count : int = 3
+var auto_retry_backoff_base : int = 10
+
 var _pending = {}
 var id : int = 0
+
+class AsyncRequest:
+	var id : int
+	var request : HTTPRequest
+	var uri : String
+	var method : int
+	var headers : PoolStringArray
+	var body : PoolByteArray
+	var retry_count := 3
+	var backoff_time := 10
+	var logger : NakamaLogger
+
+	var cancelled = false
+	var result : int = HTTPRequest.RESULT_NO_RESPONSE
+	var response_code : int = -1
+	var response_body : PoolByteArray
+	var timer : SceneTreeTimer = null
+	var cur_try : int = 1
+	var rng = RandomNumberGenerator.new()
+
+	func _init(p_id : int, p_request : HTTPRequest, p_uri : String,
+			p_method : int, p_headers : PoolStringArray, p_body : PoolByteArray,
+			p_retry_count : int, p_backoff_time : int, p_logger : NakamaLogger):
+		rng.seed = OS.get_ticks_usec()
+		id = p_id
+		request = p_request
+		uri = p_uri
+		method = p_method
+		headers = p_headers
+		body = p_body
+		retry_count = p_retry_count
+		backoff_time = p_backoff_time
+		logger = p_logger
+
+	func should_retry():
+		return cur_try < retry_count and not cancelled
+
+	func retry():
+		var time = pow(backoff_time, cur_try) * rng.randf_range(0.5, 1)
+		logger.debug("Retrying request %d. Tries left: %d. Backoff: %d ms" % [
+			id, retry_count - cur_try, time
+		])
+		cur_try += 1
+		yield(backoff(time), "completed")
+		if cancelled:
+			return
+		return yield(make_request(), "completed")
+
+	func make_request():
+		var err = request.request(uri, headers, true, method, body.get_string_from_utf8())
+		if err != OK:
+			yield(request.get_tree(), "idle_frame")
+			result = HTTPRequest.RESULT_CANT_CONNECT
+			logger.debug("Request %d failed to start, error: %d" % [id, err])
+			return
+
+		var args = yield(request, "request_completed")
+		result = args[0]
+		response_code = args[1]
+		response_body = args[3]
+
+	func backoff(p_time : int):
+		timer = request.get_tree().create_timer(p_time / 1000)
+		yield(timer, "timeout")
+		timer = null
+
+	func cancel():
+		cancelled = true
+		request.cancel_request()
+		if timer:
+			timer.time_left = 0
+		else:
+			request.call_deferred("emit_signal", "request_completed", HTTPRequest.RESULT_REQUEST_FAILED, 0, [], [])
+
+	func parse_result():
+		if cancelled:
+			return NakamaException.new("Request cancelled")
+		elif result != HTTPRequest.RESULT_SUCCESS:
+			return NakamaException.new("HTTPRequest failed!", result)
+
+		var json : JSONParseResult = JSON.parse(response_body.get_string_from_utf8())
+		if json.error != OK:
+			logger.debug("Unable to parse request %d response. JSON error: %d, response code: %d" % [
+				id, json.error, response_code
+			])
+			return NakamaException.new("Failed to decode JSON response", response_code)
+
+		if response_code != HTTPClient.RESPONSE_OK:
+			var error = ""
+			var code = -1
+			if typeof(json.result) == TYPE_DICTIONARY:
+				if "message" in json.result:
+					error = json.result["message"]
+				elif "error" in json.result:
+					error = json.result["error"]
+				else:
+					error = str(json.result)
+				code = json.result["code"] if "code" in json.result else -1
+			else:
+				error = str(json.result)
+			if typeof(error) == TYPE_DICTIONARY:
+				error = JSON.print(error)
+			logger.debug("Request %d returned response code: %d, RPC code: %d, error: %s" % [
+				id, response_code, code, error
+			])
+			return NakamaException.new(error, response_code, code)
+
+		return json.result
+
 
 # Send a HTTP request.
 # @param method - HTTP method to use for this request.
@@ -17,8 +134,9 @@ var id : int = 0
 # @param body - Request content body to set.
 # @param timeoutSec - Request timeout.
 # Returns a task which resolves to the contents of the response.
-func send_async(p_method : String, p_uri : String, p_headers : Dictionary, p_body : PoolByteArray, p_timeout : int = 3):
+func send_async(p_method : String, p_uri : String, p_headers : Dictionary, p_body : PoolByteArray):
 	var req = HTTPRequest.new()
+	req.timeout = timeout
 	if OS.get_name() != 'HTML5':
 		req.use_threads = true # Threads not available nor needed on the web.
 
@@ -39,83 +157,44 @@ func send_async(p_method : String, p_uri : String, p_headers : Dictionary, p_bod
 	for k in p_headers:
 		headers.append("%s: %s" % [k, p_headers[k]])
 
-	# Handle timeout for 3.1 compatibility
 	id += 1
-	_pending[id] = [req, OS.get_ticks_msec() + (p_timeout * 1000)]
+	var retry = auto_retry_count if auto_retry else 0
+	var backoff = auto_retry_backoff_base
+	_pending[id] = AsyncRequest.new(id, req, p_uri, method, headers, p_body, retry, backoff, logger)
 
-	logger.debug("Sending request [ID: %d, Method: %s, Uri: %s, Headers: %s, Body: %s, Timeout: %d]" % [
-		id, p_method, p_uri, p_headers, p_body.get_string_from_utf8(), p_timeout
+	logger.debug("Sending request [ID: %d, Method: %s, Uri: %s, Headers: %s, Body: %s, Timeout: %d, Retries: %d, Backoff base: %d ms]" % [
+		id, p_method, p_uri, p_headers, p_body.get_string_from_utf8(), timeout, retry, backoff
 	])
 
 	add_child(req)
-	return _send_async(req, p_uri, headers, method, p_body, id, _pending, logger)
 
-func _process(delta):
-	# Handle timeout for 3.1 compatibility
-	var ids = _pending.keys()
-	for id in ids:
-		var p = _pending[id]
-		if p[0].is_queued_for_deletion():
-			_pending.erase(id)
-			continue
-		if p[1] < OS.get_ticks_msec():
-			logger.debug("Request %d timed out" % id)
-			p[0].cancel_request()
-			_pending.erase(id)
-			p[0].emit_signal("request_completed", HTTPRequest.RESULT_REQUEST_FAILED, 0, PoolStringArray(), PoolByteArray())
+	return _send_async(id, _pending)
 
-static func _send_async(request : HTTPRequest, p_uri : String, p_headers : PoolStringArray,
-		p_method : int, p_body : PoolByteArray, p_id : int, p_pending : Dictionary, logger : NakamaLogger):
+func get_last_token():
+	return id
 
-	var err = request.request(p_uri, p_headers, true, p_method, p_body.get_string_from_utf8())
-	if err != OK:
-		yield(request.get_tree(), "idle_frame")
-		logger.debug("Request %d failed to start, error: %d" % [p_id, err])
-		request.queue_free()
-		return NakamaException.new("Request failed")
+func cancel_request(p_token):
+	if _pending.has(p_token):
+		_pending[p_token].cancel()
 
-	var args = yield(request, "request_completed")
-	var result = args[0]
-	var response_code = args[1]
-	var _headers = args[2]
-	var body = args[3]
-
-	# Will be deleted next frame
-	if not request.is_queued_for_deletion():
-		request.queue_free()
+static func _clear_request(p_request : AsyncRequest, p_pending : Dictionary, p_id : int):
+	if not p_request.request.is_queued_for_deletion():
+		p_request.logger.debug("Freeing request %d" % p_id)
+		p_request.request.queue_free()
 		p_pending.erase(p_id)
 
-	if result != HTTPRequest.RESULT_SUCCESS:
-		logger.debug("Request %d failed with result: %d, response code: %d" % [
-			p_id, result, response_code
-		])
-		return NakamaException.new("HTTPRequest failed!", result)
+static func _send_async(p_id : int, p_pending : Dictionary):
 
-	var json : JSONParseResult = JSON.parse(body.get_string_from_utf8())
-	if json.error != OK:
-		logger.debug("Unable to parse request %d response. JSON error: %d, response code: %d" % [
-			p_id, json.error, response_code
-		])
-		return NakamaException.new("Failed to decode JSON response", response_code)
+	var req : AsyncRequest = p_pending[p_id]
+	yield(req.make_request(), "completed")
 
-	if response_code != HTTPClient.RESPONSE_OK:
-		var error = ""
-		var code = -1
-		if typeof(json.result) == TYPE_DICTIONARY:
-			if "message" in json.result:
-				error = json.result["message"]
-			elif "error" in json.result:
-				error = json.result["error"]
-			else:
-				error = str(json.result)
-			code = json.result["code"] if "code" in json.result else -1
-		else:
-			error = str(json.result)
-		if typeof(error) == TYPE_DICTIONARY:
-			error = JSON.print(error)
-		logger.debug("Request %d returned response code: %d, RPC code: %d, error: %s" % [
-			p_id, response_code, code, error
+	while req.result != HTTPRequest.RESULT_SUCCESS:
+		req.logger.debug("Request %d failed with result: %d, response code: %d" % [
+			p_id, req.result, req.response_code
 		])
-		return NakamaException.new(error, response_code, code)
+		if not req.should_retry():
+			break
+		yield(req.retry(), "completed")
 
-	return json.result
+	_clear_request(req, p_pending, p_id)
+	return req.parse_result()

--- a/addons/com.heroiclabs.nakama/utils/NakamaAsyncResult.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaAsyncResult.gd
@@ -13,6 +13,9 @@ func _init(p_ex = null):
 func is_exception():
 	return get_exception() != null
 
+func was_cancelled():
+	return is_exception() and get_exception().cancelled
+
 func get_exception() -> NakamaException:
 	return _ex as NakamaException
 

--- a/addons/com.heroiclabs.nakama/utils/NakamaException.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaException.gd
@@ -7,14 +7,16 @@ class_name NakamaException
 var status_code : int = -1 setget _no_set
 var grpc_status_code : int = -1 setget _no_set
 var message : String = "" setget _no_set
+var cancelled : bool = false setget _no_set
 
 func _no_set(_p):
 	pass
 
-func _init(p_message : String = "", p_status_code : int = -1, p_grpc_status_code : int = -1):
+func _init(p_message : String = "", p_status_code : int = -1, p_grpc_status_code : int = -1, p_cancelled : bool = false):
 	status_code = p_status_code
 	grpc_status_code = p_grpc_status_code
 	message = p_message
+	cancelled = p_cancelled
 
 func _to_string() -> String:
 	return "NakamaException(StatusCode={%s}, Message='{%s}', GrpcStatusCode={%s})" % [status_code, message, grpc_status_code]


### PR DESCRIPTION
In this PR:

- Big refactor of NakamaHTTPAdapter
- Automatic HTTP request retry, with exponential backoff
- Add ability to cancel request in-flight

```gdscript

var req = client.authenticate_device_async("0123456789")
var token = client.last_cancel_token # Get generated token (ID) of the last request.
client.cancel_request(token)
yield(req, "completed") # NakamException("Request cancelled!")

```

Smart features can be configured via:

```gdscript

client.auto_retry = true
client.auto_retry_count = 5
client.auto_retry_backoff_base = 20
```

I'm still wrapping my head around the socket reconnect.