### PR TITLE
Correctly (de-)serialize floats in dictionaries to fix "numeric_properties"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
-- Fix Dictionary serialization (e.g. "NakamaSocket.add_matchmaker_async" "p_string_props").
+- Fix Dictionary serialization (e.g. "NakamaSocket.add_matchmaker_async" "p_string_props" and "p_numeric_props").
 - Pass join metadata onwards into match join message.
 - Don't stop processing messages when the game is paused.
 - Fix "rpc_async", "rpc_async_with_key". Now uses GET request only if no payload is passed.

--- a/addons/com.heroiclabs.nakama/utils/NakamaSerializer.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaSerializer.gd
@@ -44,9 +44,16 @@ static func serialize(p_obj : Object) -> Dictionary:
 						dict[l] = serialize(val[l])
 				else: # Map of simple types
 					for l in val:
-						if typeof(val[l]) != content:
+						var e = val[l]
+						if content == TYPE_REAL:
+							e = float(e)
+						elif content == TYPE_INT:
+							e = int(e)
+						elif content == TYPE_BOOL:
+							e = bool(e)
+						if typeof(e) != content:
 							continue
-						dict[l] = val[l]
+						dict[l] = e
 				out[k] = dict
 			_:
 				out[k] = val
@@ -89,6 +96,8 @@ static func deserialize(p_ns : GDScript, p_cls_name : String, p_dict : Dictionar
 				for l in val:
 					if typeof(content) == TYPE_STRING:
 						v[l] = deserialize(p_ns, content, val[l])
+					elif content == TYPE_REAL:
+						v[l] = float(val[l])
 					elif content == TYPE_INT:
 						v[l] = int(val[l])
 					elif content == TYPE_BOOL:
@@ -105,6 +114,8 @@ static func deserialize(p_ns : GDScript, p_cls_name : String, p_dict : Dictionar
 				for e in val:
 					if typeof(content) == TYPE_STRING:
 						v.append(deserialize(p_ns, content, e))
+					elif content == TYPE_REAL:
+						v.append(float(e))
 					elif content == TYPE_INT:
 						v.append(int(e))
 					elif content == TYPE_BOOL:

--- a/test_suite/tests/socket_multi_test.gd
+++ b/test_suite/tests/socket_multi_test.gd
@@ -1,7 +1,8 @@
 extends "res://base_test.gd"
 
 var content = {"My": "message"}
-var match_props = {"region": "europe"}
+var match_string_props = {"region": "europe"}
+var match_numeric_props = {"rank": 8}
 var got_msg = false
 var got_match = false
 var socket1 = null
@@ -45,10 +46,10 @@ func setup():
 	if assert_false(msg_ack.is_exception()):
 		return
 
-	var ticket1 = yield(socket1.add_matchmaker_async("+properties.region:europe", 2, 8, match_props), "completed")
+	var ticket1 = yield(socket1.add_matchmaker_async("+properties.region:europe +properties.rank:>=7 +properties.rank:<=9", 2, 8, match_string_props, match_numeric_props), "completed")
 	if assert_false(ticket1.is_exception()):
 		return
-	var ticket2 = yield(socket2.add_matchmaker_async("+properties.region:europe", 2, 8, match_props), "completed")
+	var ticket2 = yield(socket2.add_matchmaker_async("+properties.region:europe +properties.rank:>=7 +properties.rank:<=9", 2, 8, match_string_props, match_numeric_props), "completed")
 	if assert_false(ticket2.is_exception()):
 		return
 
@@ -59,9 +60,13 @@ func _on_socket1_message(msg):
 	check_end()
 
 func _on_socket1_matchmaker_matched(p_matchmaker_matched):
-	if assert_equal(JSON.print(p_matchmaker_matched.users[0].string_properties), JSON.print(match_props)):
+	if assert_equal(JSON.print(p_matchmaker_matched.users[0].string_properties), JSON.print(match_string_props)):
 		return
-	if assert_equal(JSON.print(p_matchmaker_matched.users[1].string_properties), JSON.print(match_props)):
+	if assert_equal(JSON.print(p_matchmaker_matched.users[0].numeric_properties), JSON.print(match_numeric_props)):
+		return
+	if assert_equal(JSON.print(p_matchmaker_matched.users[1].string_properties), JSON.print(match_string_props)):
+		return
+	if assert_equal(JSON.print(p_matchmaker_matched.users[1].numeric_properties), JSON.print(match_numeric_props)):
 		return
 	got_match = true
 	check_end()


### PR DESCRIPTION
Fixes #85, where "numeric_properties" were being discarded if using integers. Like I wrote there:

> Normally, in GDScript, ints are silently cast to floats when assigning to a float variable, so it should probably just convert from an int to a float in this case too.

This implements that, converting from ints to floats when a dictionary takes floating-point values.

Also, when I was updating `test_suite/tests/socket_multi_test.gd` to confirm this fix, I noticed that when deserializing "numeric_properties" coming back from Nakama, the values were left as strings! So, this also updates `deserialize()` to convert dictionary values to floats if they are marked as floats in the schema - it was already doing this for ints and bools.

And since `deserialize()` was converting values back to bools and ints, I figured it probably made sense for `serialize()` to convert to them too, given that (1) it's doing the same in other places and (2) GDScript also silently converts to int and bool on assignment, which is the same justification that I gave for converting to floats above.

This should improve type consistency overall.