### PR TITLE
NakamaSocket: Emit errors received from the server on the "received_error" signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - Fix client errors parsing in Nakama 3.x
 - Make it possible to omit the label and query on NakamaClient.list_matches_async().
 
+### Backwards incompatible changes
+
+- The "received_error" signal on "NakamaSocket" is now emited with an "NakamaRTAPI.Error" object received from the server.
+  Previously, it was emitted with an integer error code when the socket failed to connect.
+  If you have old code using the "received_error" signal, you can switch to the new "connection_error" signal, which was added to replace it.
+
 ## [2.1.0] - 2020-08-01
 
 ### Added

--- a/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
@@ -167,6 +167,58 @@ class ChannelPresenceEvent extends NakamaAsyncResult:
 		return "channel_presence_event"
 
 
+# Describes an error which occurred on the server.
+class Error extends NakamaAsyncResult:
+
+	const _SCHEMA = {
+		"code": {"name": "code", "type": TYPE_INT, "required": true},
+		"message": {"name": "message", "type": TYPE_STRING, "required": true},
+		"context": {"name": "context", "type": TYPE_DICTIONARY, "required": false, "content": TYPE_STRING},
+	}
+
+	# The selection of possible error codes.
+	enum Code {
+		# An unexpected result from the server.
+		RUNTIME_EXCEPTION = 0,
+		# The server received a message which is not recognised.
+		UNRECOGNIZED_PAYLOAD = 1,
+		# A message was expected but contains no content.
+		MISSING_PAYLOAD = 2,
+		# Fields in the message have an invalid format.
+		BAD_INPUT = 3,
+		# The match id was not found.
+		MATCH_NOT_FOUND = 4,
+		# The match join was rejected.
+		MATCH_JOIN_REJECTED = 5,
+		# The runtime function does not exist on the server.
+		RUNTIME_FUNCTION_NOT_FOUND = 6,
+		#The runtime function executed with an error.
+		RUNTIME_FUNCTION_EXCEPTION = 7,
+	}
+
+	# The error code which should be one of "Error.Code" enums.
+	var code : int
+
+	# A message in English to help developers debug the response.
+	var message : String
+
+	# Additional error details which may be different for each response.
+	var context : Dictionary
+
+	func _init(p_ex = null).(p_ex):
+		pass
+
+	func _to_string():
+		if is_exception(): return get_exception()._to_string()
+		return "Error<code=%s, messages=%s, context=%s>" % [code, message, context]
+
+	static func create(p_ns : GDScript, p_dict : Dictionary) -> Error:
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "Error", p_dict), Error) as Error
+
+	static func get_result_key() -> String:
+		return "error"
+
+
 # A multiplayer match.
 class Match extends NakamaAsyncResult:
 

--- a/addons/com.heroiclabs.nakama/socket/NakamaSocketAdapter.gd
+++ b/addons/com.heroiclabs.nakama/socket/NakamaSocketAdapter.gd
@@ -15,7 +15,7 @@ signal connected()
 # A signal emitted when the socket is disconnected.
 signal closed()
 
-# A signal emitted when the socket has an error when connected.
+# A signal emitted when the socket has an error when connecting.
 signal received_error(p_exception)
 
 # A signal emitted when the socket receives a message.


### PR DESCRIPTION
Per #42, currently, error messages sent by the server and received on the socket are logged (as an "Unhandled response"), but _not_ made available to the developer.

This PR parses those messages and emits them on the "received_error" signal, which is in line with what other client libraries are doing (ex. C# has a "ReceivedError" event for the same purpose).

However, the "received_error" signal already existed, and was previously emitted with integer error codes, when errors occurred while the socket is connecting. This PR, adds a new "connection_error" signal for that purpose.

Because this changes the purpose and signature of the "received_error" signal, it breaks backwards compatibility. An alternative option, would be to leave the "received_error" signal as-is, and add a new signal for the error messages sent by the server. This wouldn't break compatibility with older version of the Godot client library, but would not match the way that other clients work (ie. the "received_error" signal in Godot would do a different thing than the "ReceivedError" event in C#).

This PR takes the stand that breaking compatibility in order to match other clients is worth it. However, if others disagree, I'd be happy to switch to the alternative approach instead.

Fixes #42 