### PR TITLE
Expose the "seen_before" property on "NakamaAPI.ApiValidatedPurchase"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project are documented below.
 
 The format is based on [keep a changelog](http://keepachangelog.com/) and this project uses [semantic versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Expose the "seen_before" property on "NakamaAPI.ApiValidatedPurchase"
+
 ## [3.0.0] - 2022-03-28
 
 ### Added

--- a/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
@@ -3025,6 +3025,7 @@ class ApiValidatedPurchase extends NakamaAsyncResult:
 		"product_id": {"name": "_product_id", "type": TYPE_STRING, "required": false},
 		"provider_response": {"name": "_provider_response", "type": TYPE_STRING, "required": false},
 		"purchase_time": {"name": "_purchase_time", "type": TYPE_STRING, "required": false},
+		"seen_before": {"name": "_seen_before", "type": TYPE_BOOL, "required": false},
 		"store": {"name": "_store", "type": TYPE_INT, "required": false},
 		"transaction_id": {"name": "_transaction_id", "type": TYPE_STRING, "required": false},
 		"update_time": {"name": "_update_time", "type": TYPE_STRING, "required": false},
@@ -3059,6 +3060,12 @@ class ApiValidatedPurchase extends NakamaAsyncResult:
 	var _purchase_time = null
 	func _get_purchase_time() -> String:
 		return "" if not _purchase_time is String else String(_purchase_time)
+
+	# Whether the purchase had already been validated by Nakama before.
+	var seen_before : bool setget , _get_seen_before
+	var _seen_before = null
+	func _get_seen_before() -> bool:
+		return false if not _seen_before is bool else bool(_seen_before)
 
 	# 
 	var store : int setget , _get_store
@@ -3096,6 +3103,7 @@ class ApiValidatedPurchase extends NakamaAsyncResult:
 		output += "product_id: %s, " % _product_id
 		output += "provider_response: %s, " % _provider_response
 		output += "purchase_time: %s, " % _purchase_time
+		output += "seen_before: %s, " % _seen_before
 		output += "store: %s, " % _store
 		output += "transaction_id: %s, " % _transaction_id
 		output += "update_time: %s, " % _update_time


### PR DESCRIPTION
Added by running the codegen on the Swagger definition from Nakama 3.10.0.

I didn't use the Swagger file from Nakama 3.11.0 due to this issue: https://github.com/heroiclabs/nakama/issues/823

Depending on how that issue pans out, I can make a future PR to update to the Nakama 3.11.0 definition, if needed.