### PR TITLE
Add support for creating match by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - Expose the "seen_before" property on "NakamaAPI.ApiValidatedPurchase"
+- Add support for creating match by name
 
 ## [3.0.0] - 2022-03-28
 

--- a/addons/com.heroiclabs.nakama/api/NakamaRTMessage.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaRTMessage.gd
@@ -137,13 +137,18 @@ class ChannelMessageUpdate extends NakamaAsyncResult:
 	func _to_string():
 		return "ChannelMessageUpdate<channel_id=%s, message_id=%s, content=%s>" % [channel_id, message_id, content]
 
+
 # A create message for a match on the server.
 class MatchCreate extends NakamaAsyncResult:
 
-	const _SCHEMA = {}
+	const _SCHEMA = {
+		"name": {"name": "name", "type": TYPE_STRING, "required": false},
+	}
+	
+	var name = null
 
-	func _init():
-		pass
+	func _init(p_name = null):
+		name = p_name if p_name else null
 
 	func serialize():
 		return NakamaSerializer.serialize(self)
@@ -152,7 +157,7 @@ class MatchCreate extends NakamaAsyncResult:
 		return "match_create"
 
 	func _to_string():
-		return "MatchCreate<>"
+		return "MatchCreate<name=%s>" % [name]
 
 
 # A join message for a match on the server.

--- a/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
+++ b/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
@@ -320,12 +320,11 @@ func add_matchmaker_async(p_query : String = "*", p_min_count : int = 2, p_max_c
 		NakamaRTAPI.MatchmakerTicket
 	)
 
-## <summary>
-## Create a multiplayer match on the server.
-## </summary>
-## Returns a task to represent the asynchronous operation.
-func create_match_async():
-	return _send_async(NakamaRTMessage.MatchCreate.new(), NakamaRTAPI.Match)
+# Create a multiplayer match on the server.
+# @param p_name - Optional name to use when creating the match.
+# Returns a task to represent the asynchronous operation.
+func create_match_async(p_name : String = ''):
+	return _send_async(NakamaRTMessage.MatchCreate.new(p_name), NakamaRTAPI.Match)
 
 # Subscribe to one or more users for their status updates.
 # @param p_user_ids - The IDs of users.


### PR DESCRIPTION
Fixes #98 

I tested that using a name joins a consistent match ID, that omitting the name will join a unique match ID, and that omitting the name while using an older version of Nakama (I used 3.4.0) will still work fine.