### PR TITLE
Add support for "count_multiple" on "NakamaSocket.add_matchmaker_async()" and …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 
 - Expose the "seen_before" property on "NakamaAPI.ApiValidatedPurchase"
 - Add support for creating match by name
+- Add support for "count_multple" on "NakamaSocket.add_matchmaker_async()" and "NakamaSocket.add_matchmaker_party_async()"
 
 ## [3.0.0] - 2022-03-28
 

--- a/addons/com.heroiclabs.nakama/api/NakamaRTMessage.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaRTMessage.gd
@@ -248,6 +248,7 @@ class MatchmakerAdd extends NakamaAsyncResult:
 		"min_count": {"name": "min_count", "type": TYPE_INT, "required": true},
 		"numeric_properties": {"name": "numeric_properties", "type": TYPE_DICTIONARY, "required": false, "content": TYPE_REAL},
 		"string_properties": {"name": "string_properties", "type": TYPE_DICTIONARY, "required": false, "content": TYPE_STRING},
+		"count_multiple": {"name": "count_multiple", "type": TYPE_INT, "required": false},
 	}
 
 	var query : String = "*"
@@ -255,17 +256,20 @@ class MatchmakerAdd extends NakamaAsyncResult:
 	var min_count : int = 2
 	var string_properties : Dictionary
 	var numeric_properties : Dictionary
+	var count_multiple
 
 	func _no_set(_val):
 		return
 
 	func _init(p_query : String = "*", p_min_count : int = 2, p_max_count : int = 8,
-			p_string_props : Dictionary = Dictionary(), p_numeric_props : Dictionary = Dictionary()):
+			p_string_props : Dictionary = Dictionary(), p_numeric_props : Dictionary = Dictionary(),
+			p_count_multiple : int = 0):
 		query = p_query
 		min_count = p_min_count
 		max_count = p_max_count
 		string_properties = p_string_props
 		numeric_properties = p_numeric_props
+		count_multiple = p_count_multiple if p_count_multiple > 0 else null
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -274,7 +278,7 @@ class MatchmakerAdd extends NakamaAsyncResult:
 		return "matchmaker_add"
 
 	func _to_string():
-		return "MatchmakerAdd<query=%s, max_count=%d, min_count=%d, numeric_properties=%s, string_properties=%s>" % [query, max_count, min_count, numeric_properties, string_properties]
+		return "MatchmakerAdd<query=%s, max_count=%d, min_count=%d, numeric_properties=%s, string_properties=%s, count_multiple=%s>" % [query, max_count, min_count, numeric_properties, string_properties, count_multiple]
 
 
 # Remove the user from the matchmaker pool by ticket.
@@ -558,14 +562,17 @@ class PartyMatchmakerAdd extends NakamaAsyncResult:
 	var string_properties : Dictionary
 	# Numeric properties.
 	var numeric_properties : Dictionary
+	# Optional multiple of the count that must be satisfied.
+	var count_multiple
 
-	func _init(p_id : String, p_min_count : int, p_max_count : int, p_query : String, p_string_properties = null, p_numeric_properties = null):
+	func _init(p_id : String, p_min_count : int, p_max_count : int, p_query : String, p_string_properties = null, p_numeric_properties = null, p_count_multiple = null):
 		party_id = p_id
 		min_count = p_min_count
 		max_count = p_max_count
 		query = p_query
 		string_properties = p_string_properties
 		numeric_properties = p_numeric_properties
+		count_multiple = p_count_multiple
 
 	func serialize():
 		return NakamaSerializer.serialize(self)
@@ -574,7 +581,7 @@ class PartyMatchmakerAdd extends NakamaAsyncResult:
 		return "party_matchmaker_add"
 
 	func _to_string():
-		return "PartyMatchmakerAdd<party_id=%s, min_count=%d, max_count=%d, query=%s, string_properties=%s, numeric_properties=%s>" % [party_id, min_count, max_count, query, string_properties, numeric_properties]
+		return "PartyMatchmakerAdd<party_id=%s, min_count=%d, max_count=%d, query=%s, string_properties=%s, numeric_properties=%s, count_multiple>" % [party_id, min_count, max_count, query, string_properties, numeric_properties, count_multiple]
 
 
 # Cancel a party matchmaking process using a ticket.

--- a/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
+++ b/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
@@ -312,11 +312,13 @@ func connect_async(p_session : NakamaSession, p_appear_online : bool = false, p_
 # @param p_max_count - The maximum number of players to compete against in a match.
 # @param p_string_properties - A set of key/value properties to provide to searches.
 # @param p_numeric_properties - A set of key/value numeric properties to provide to searches.
+# @param p_count_multiple - Optional multiple of the count that must be satisfied.
 # Returns a task which resolves to a matchmaker ticket object.
 func add_matchmaker_async(p_query : String = "*", p_min_count : int = 2, p_max_count : int = 8,
-		p_string_props : Dictionary = {}, p_numeric_props : Dictionary = {}) -> NakamaRTAPI.MatchmakerTicket:
+		p_string_props : Dictionary = {}, p_numeric_props : Dictionary = {},
+		p_count_multiple : int = 0) -> NakamaRTAPI.MatchmakerTicket:
 	return _send_async(
-		NakamaRTMessage.MatchmakerAdd.new(p_query, p_min_count, p_max_count, p_string_props, p_numeric_props),
+		NakamaRTMessage.MatchmakerAdd.new(p_query, p_min_count, p_max_count, p_string_props, p_numeric_props, p_count_multiple),
 		NakamaRTAPI.MatchmakerTicket
 	)
 
@@ -495,12 +497,14 @@ func accept_party_member_async(p_party_id : String, p_presence : NakamaRTAPI.Use
 # @param p_max_count - Maximum total user count to match together.
 # @param p_string_properties - String properties.
 # @param p_numeric_properties - Numeric properties.
+# @param p_count_multiple - Optional multiple of the count that must be satisfied.
 # Returns a task to represent the asynchronous operation.
 func add_matchmaker_party_async(p_party_id : String, p_query : String = "*", p_min_count : int = 2,
-	p_max_count : int = 8, p_string_properties = {}, p_numeric_properties = {}):
+	p_max_count : int = 8, p_string_properties = {}, p_numeric_properties = {}, p_count_multiple : int = 0):
 	return _send_async(
 		NakamaRTMessage.PartyMatchmakerAdd.new(p_party_id, p_min_count,
-			p_max_count, p_query, p_string_properties, p_numeric_properties))
+			p_max_count, p_query, p_string_properties, p_numeric_properties,
+			p_count_multiple if p_count_multiple > 0 else null))
 
 # End a party, kicking all party members and closing it.
 # @param p_party_id - The ID of the party.


### PR DESCRIPTION
… "NakamaSocket.add_matchmaker_party_async()"

The "count_multiple" property was added in Nakama 3.11.0

When testing this, I found a potentially serious issue in Nakama's matchmaking in 3.11.0 which I reported here https://github.com/heroiclabs/nakama/issues/827

However, I was ultimately able to test it, and it appeared to be working.