### PR TITLE
Fix NakamaSocket.add_matchmaker_party_async() and the tests for it

### DIFF
--- a/addons/com.heroiclabs.nakama/api/NakamaRTMessage.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaRTMessage.gd
@@ -144,7 +144,7 @@ class MatchCreate extends NakamaAsyncResult:
 	const _SCHEMA = {
 		"name": {"name": "name", "type": TYPE_STRING, "required": false},
 	}
-	
+
 	var name = null
 
 	func _init(p_name = null):
@@ -581,7 +581,7 @@ class PartyMatchmakerAdd extends NakamaAsyncResult:
 		return "party_matchmaker_add"
 
 	func _to_string():
-		return "PartyMatchmakerAdd<party_id=%s, min_count=%d, max_count=%d, query=%s, string_properties=%s, numeric_properties=%s, count_multiple>" % [party_id, min_count, max_count, query, string_properties, numeric_properties, count_multiple]
+		return "PartyMatchmakerAdd<party_id=%s, min_count=%d, max_count=%d, query=%s, string_properties=%s, numeric_properties=%s, count_multiple=%s>" % [party_id, min_count, max_count, query, string_properties, numeric_properties, count_multiple]
 
 
 # Cancel a party matchmaking process using a ticket.

--- a/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
+++ b/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
@@ -504,7 +504,8 @@ func add_matchmaker_party_async(p_party_id : String, p_query : String = "*", p_m
 	return _send_async(
 		NakamaRTMessage.PartyMatchmakerAdd.new(p_party_id, p_min_count,
 			p_max_count, p_query, p_string_properties, p_numeric_properties,
-			p_count_multiple if p_count_multiple > 0 else null))
+			p_count_multiple if p_count_multiple > 0 else null),
+		NakamaRTAPI.PartyMatchmakerTicket)
 
 # End a party, kicking all party members and closing it.
 # @param p_party_id - The ID of the party.

--- a/test_suite/tests/socket_party_test.gd
+++ b/test_suite/tests/socket_party_test.gd
@@ -38,7 +38,6 @@ func setup():
 	socket2.connect("received_party_close", self, "_on_party_close")
 	socket2.connect("received_party_join_request", self, "_on_party_join_request")
 	socket2.connect("received_party_leader", self, "_on_party_leader")
-	socket2.connect("received_party_matchmaker_ticket", self, "_on_party_ticket")
 	socket2.connect("received_party_presence", self, "_on_party_presence")
 
 	var done2 = yield(socket2.connect_async(session2), "completed")
@@ -77,6 +76,7 @@ func _on_party_leader(party_leader : NakamaRTAPI.PartyLeader):
 	var ticket = yield(socket2.add_matchmaker_party_async(party_leader.party_id), "completed")
 	if assert_false(ticket.is_exception()):
 		return
+	_on_party_ticket(ticket)
 
 func _on_party_ticket(ticket : NakamaRTAPI.PartyMatchmakerTicket):
 	prints("_on_party_ticket", ticket)


### PR DESCRIPTION
This fixes an issue in `NakamaSocket.add_matchmaker_party_async()` that went unnoticed, in part, because of an issue in the tests for it. This also fixes the tests!

I discovered this while working on the Godot 4 port on PR #103.