### PR TITLE
Fix MatchData.op_code type in schema to TYPE_INT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - Fix NakamaSocket.add_matchmaker_party_async() and the tests for it
+- Fix MatchData.op_code type in schema to TYPE_INT
 
 ## [3.1.0] - 2022-04-28
 

--- a/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
@@ -268,7 +268,7 @@ class MatchData extends NakamaAsyncResult:
 	const _SCHEMA = {
 		"match_id": {"name": "match_id", "type": TYPE_STRING, "required": true},
 		"presence": {"name": "presence", "type": "UserPresence", "required": false},
-		"op_code": {"name": "op_code", "type": TYPE_STRING, "required": false},
+		"op_code": {"name": "op_code", "type": TYPE_INT, "required": false},
 		"data": {"name": "data", "type": TYPE_STRING, "required": false}
 	}
 


### PR DESCRIPTION
This must work in Godot 3 due to some automatic type casting. I discovered this while testing in Godot 4, where it isn't automatically casting from string to integer.