### PR TITLE
Add support for receiving binary data in "NakamaRTAPI.MatchState"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 - Fix NakamaSocket.add_matchmaker_party_async() and the tests for it
 - Fix MatchData.op_code type in schema to TYPE_INT
 
+### Added
+
+- Add support for receiving binary data in "NakamaRTAPI.MatchState"
+
 ## [3.1.0] - 2022-04-28
 
 ### Added

--- a/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
@@ -282,8 +282,14 @@ class MatchData extends NakamaAsyncResult:
 	# The user that sent this game state update.
 	var presence : UserPresence
 
-	# The byte contents of the state change.
-	var data : String
+	# The contents of the state change decoded as a UTF-8 string.
+	var data : String setget , get_data
+
+	# The raw base64-encoded contents of the state change.
+	var base64_data : String
+
+	# The contents of the state change decoded as binary data.
+	var binary_data : PoolByteArray setget , get_binary_data
 
 	func _init(p_ex = null).(p_ex):
 		pass
@@ -294,12 +300,24 @@ class MatchData extends NakamaAsyncResult:
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> MatchData:
 		var out := _safe_ret(NakamaSerializer.deserialize(p_ns, "MatchData", p_dict), MatchData) as MatchData
-		if out.data: # Decode base64 received data
-			out.data = Marshalls.base64_to_utf8(out.data)
+		# Store the base64 data, ready to be decoded when the developer requests it.
+		if out.data:
+			out.base64_data = out.data
+			out.data = ''
 		return out
 
 	static func get_result_key() -> String:
 		return "match_data"
+
+	func get_data():
+		if not data and base64_data:
+			data = Marshalls.base64_to_utf8(base64_data)
+		return data
+
+	func get_binary_data():
+		if not binary_data and base64_data:
+			binary_data = Marshalls.base64_to_raw(base64_data)
+		return binary_data
 
 
 # A batch of join and leave presences for a match.


### PR DESCRIPTION
When you send match state via `NakamaSocket.send_match_state_async()` it takes a string as the data, which it'll automatically base64 encode. Then when the data is received by another client on the `received_match_state` signal, they get a `NakamaRTAPI.MatchState` object, which automatically decodes from base64 to string data. Because of this, it's not possible to send arbitrary binary data this way, because not all binary data can be represented in a UTF-8 string (there'd be an error encoding or decoding it as UTF-8).

There is the `NakamaSocket.send_match_state_raw_async()` method that takes binary data, and directly encodes it as base64, without ever converting it to a string (avoiding an UTF-8 encoding errors). **However, when this is received by another client, `NakamaRTAPI.MatchState` will still try to automatically decode from base64 to a UTF-8 string!** This will lead to UTF-8 encoding errors if some part of the binary data can't be represented as a UTF-8 string.

This PR aims to fix that, by storing the data on `NakamaRTAPI.MatchState` as base64, and only decoding it to either a string or binary data when requested by the developer:

1. If they access `MatchState.data` then it'll decode it from base64 as a UTF-8 string. This is the original name of the property, so this will maintain backwards compatibility, and existing games/apps using the client will keep working without changes.
2. If they access 'MatchState.binary_data` then it'll decode it from base64 to a `PoolByteArray`. This is an API addition.

Looking at other Nakama clients, it appears they always deal with the match state data as binary, and don't automatically convert it to a string. Digging into the Git repo, it appears the Godot client worked this way very early on, as far back as 861dc846d5a2e9b91944531797e5e826f4c48dda, which is within minutes of when the repo was first created.

It would be nice to use binary data by default like the other clients, but that would break backwards compatibility in a pretty big way, so I think the approach in this PR is the best compromise!