### PR TITLE
Fix friend requests failing due to empty request body

### DIFF
--- a/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
@@ -3342,6 +3342,9 @@ class ApiClient extends Reference:
 	func cancel_request(p_token):
 		if p_token:
 			_http_adapter.cancel_request(p_token)
+	
+	func create_empty_json_body() -> PoolByteArray:
+		return to_json({}).to_utf8()
 
 	# A healthcheck which load balancers can use to check the service.
 	func healthcheck_async(
@@ -4369,6 +4372,7 @@ class ApiClient extends Reference:
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
+		content = create_empty_json_body()
 
 		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:
@@ -4402,6 +4406,7 @@ class ApiClient extends Reference:
 		headers["Authorization"] = header
 
 		var content : PoolByteArray
+		content = create_empty_json_body()
 
 		var result = yield(_http_adapter.send_async(method, uri, headers, content), "completed")
 		if result is NakamaException:


### PR DESCRIPTION
Adding and blocking friends is currently broken and corresponding requests will fail:
```
NakamaException(StatusCode={4}, Message='{HTTPRequest failed!}', GrpcStatusCode={-1})
```
This appears to be caused by the empty `PoolByteArray` passed to `send_async` as the request body. Populating that body with an empty JSON object (`{}`) fixes the issue and results in successful requests. 

Refer to [this](https://forum.heroiclabs.com/t/unity-client-addfriendsasync-method-returns-error/2543/2) forum post for what is likely the same issue observed in the Unity client. 

There are several more functions in `ApiClient` that also pass an empty `PoolByteArray`. As far as i can tell this fix should however not be applied to all of them. Perhaps testing them one-by-one would be a worthwhile thing to do. This PR currently only affects `add_friends_async` and `block_friends_async` .