### PR TITLE
Add support for sending and receiving binary data in "NakamaRTAPI.PartyData"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - Add support for receiving binary data in "NakamaRTAPI.MatchState"
+- Add support for sending and receiving binary data in "NakamaRTAPI.PartyData"
 
 ## [3.1.0] - 2022-04-28
 

--- a/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
+++ b/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
@@ -574,3 +574,12 @@ func remove_party_member_async(p_party_id : String, p_presence : NakamaRTAPI.Use
 func send_party_data_async(p_party_id : String, p_op_code : int, p_data:String = ""):
 	var base64_data = null if p_data.empty() else Marshalls.utf8_to_base64(p_data)
 	return _send_async(NakamaRTMessage.PartyDataSend.new(p_party_id, p_op_code, base64_data))
+
+# Send data to a party.
+# @param p_party_id - Party ID to send to.
+# @param p_op_code - Op code value.
+# @param data - Data payload, if any.
+# Returns a task which represents the asynchronous operation.
+func send_party_data_raw_async(p_party_id : String, p_op_code : int, p_data:PoolByteArray):
+	var base64_data = null if p_data.empty() else Marshalls.raw_to_base64(p_data)
+	return _send_async(NakamaRTMessage.PartyDataSend.new(p_party_id, p_op_code, base64_data))


### PR DESCRIPTION
The same problem that was fixed for `NakamaRTAPI.MatchState` in #112 exists for `NakamaRTAPI.PartyData`, except that there wasn't an existing method on `NakamaSocket` for sending binary party data. This PR makes it possible to both send and receive binary party data, using the same API as with binary match data.