### PR TITLE
Fix for Godot String function name change

### DIFF
--- a/addons/com.heroiclabs.nakama/utils/NakamaSerializer.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaSerializer.gd
@@ -147,7 +147,7 @@ static func escape_http(p_str : String) -> String:
 			(o >= '0' and o <= '9')):
 			out += o
 		else:
-			for b in o.to_utf8():
+			for b in o.to_utf8_buffer():
 				out += "%%%s" % to_hex(b)
 	return out
 


### PR DESCRIPTION
A call In `escape_http()` is failing in Godot 4 alpha 14, seemingly due to a name-change from [`to_utf8()`](https://docs.godotengine.org/en/stable/classes/class_string.html#class-string-method-to-utf8) in 3 to [`to_utf8_buffer()`](https://docs.godotengine.org/en/latest/classes/class_string.html#class-string-method-to-utf8-buffer) in 4.