### PR TITLE
Use the refactored WebSocket API

### DIFF
--- a/addons/com.heroiclabs.nakama/socket/NakamaSocketAdapter.gd
+++ b/addons/com.heroiclabs.nakama/socket/NakamaSocketAdapter.gd
@@ -4,7 +4,8 @@ extends Node
 # An adapter which implements a socket with a protocol supported by Nakama.
 class_name NakamaSocketAdapter
 
-var _ws := WebSocketClient.new()
+var _ws := WebSocketPeer.new()
+var _ws_last_state := WebSocketPeer.STATE_CLOSED
 var _timeout : int = 30
 var _start : int = 0
 var logger = NakamaLogger.new()
@@ -23,60 +24,52 @@ signal received(p_bytes) # PackedByteArray
 
 # If the socket is connected.
 func is_connected_to_host():
-	return _ws.get_connection_status() == WebSocketClient.CONNECTION_CONNECTED
+	return _ws.get_ready_state() == WebSocketPeer.STATE_OPEN
 
 # If the socket is connecting.
 func is_connecting_to_host():
-	return _ws.get_connection_status() == WebSocketClient.CONNECTION_CONNECTING
+	return _ws.get_ready_state() == WebSocketPeer.STATE_CONNECTING
 
 # Close the socket with an asynchronous operation.
 func close():
-	_ws.disconnect_from_host()
+	_ws.close()
 
 # Connect to the server with an asynchronous operation.
 # @param p_uri - The URI of the server.
 # @param p_timeout - The timeout for the connect attempt on the socket.
 func connect_to_host(p_uri : String, p_timeout : int):
-	_ws.disconnect_from_host()
 	_timeout = p_timeout
 	_start = Time.get_unix_time_from_system()
 	var err = _ws.connect_to_url(p_uri)
 	if err != OK:
 		logger.debug("Error connecting to host %s" % p_uri)
 		call_deferred("emit_signal", "received_error", err)
+		return
+	_ws_last_state = WebSocketPeer.STATE_CLOSED
 
 # Send data to the server with an asynchronous operation.
 # @param p_buffer - The buffer with the message to send.
 # @param p_reliable - If the message should be sent reliably (will be ignored by some protocols).
 func send(p_buffer : PackedByteArray, p_reliable : bool = true) -> int:
-	return _ws.get_peer(1).put_packet(p_buffer)
+	return _ws.send(p_buffer, WebSocketPeer.WRITE_MODE_TEXT)
 
 func _process(delta):
-	if _ws.get_connection_status() == WebSocketClient.CONNECTION_CONNECTING:
-		if _start + _timeout < Time.get_unix_time_from_system():
-			logger.debug("Timeout when connecting to socket")
-			emit_signal("received_error", ERR_TIMEOUT)
-			_ws.disconnect_from_host()
-		else:
-			_ws.poll()
-	if _ws.get_connection_status() != WebSocketClient.CONNECTION_DISCONNECTED:
+	if _ws.get_ready_state() != WebSocketPeer.STATE_CLOSED:
 		_ws.poll()
 
-func _init():
-	_ws.data_received.connect(self._received)
-	_ws.connection_established.connect(self._connected)
-	_ws.connection_error.connect(self._error)
-	_ws.connection_closed.connect(self._closed)
+	var state = _ws.get_ready_state()
+	if _ws_last_state != state:
+		_ws_last_state = state
+		if state == WebSocketPeer.STATE_OPEN:
+			connected.emit()
+		elif state == WebSocketPeer.STATE_CLOSED:
+			closed.emit()
 
-func _received():
-	emit_signal("received", _ws.get_peer(1).get_packet())
+	if state == WebSocketPeer.STATE_CONNECTING:
+		if _start + _timeout < Time.get_unix_time_from_system():
+			logger.debug("Timeout when connecting to socket")
+			received_error.emit(ERR_TIMEOUT)
+			_ws.close()
 
-func _connected(p_protocol : String):
-	_ws.get_peer(1).set_write_mode(WebSocketPeer.WRITE_MODE_TEXT)
-	emit_signal("connected")
-
-func _error():
-	emit_signal("received_error", FAILED)
-
-func _closed(p_clean : bool):
-	emit_signal("closed")
+	while _ws.get_ready_state() == WebSocketPeer.STATE_OPEN and _ws.get_available_packet_count():
+		received.emit(_ws.get_packet())

--- a/addons/com.heroiclabs.nakama/utils/NakamaMultiplayerPeer.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaMultiplayerPeer.gd
@@ -61,8 +61,8 @@ func _get_packet_peer() -> int:
 func _is_server() -> bool:
 	return _self_id == 1
 
-func _poll() -> int:
-	return OK
+func _poll() -> void:
+	pass
 
 func _get_unique_id() -> int:
 	return _self_id


### PR DESCRIPTION
This updates the NakamaSocketAdaptor to use the refactored WebSocket API in PR https://github.com/godotengine/godot/pull/66594

Leaving as a draft until the refactor is in a Godot 4 beta release, and the changes from PR #134 are merged.

Fixes #137