### PR TITLE
Remove hacks for GDScript bugs that are fixed as of 4.0-beta12

### DIFF
--- a/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
@@ -3713,7 +3713,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -3731,17 +3731,9 @@ class ApiClient extends RefCounted:
 		var urlpath : String = "/v2/account/authenticate/apple"
 		var query_params = ""
 		if p_create != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_create
-			tmp = tmp
-			query_params += "create=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "create=%s&" % str(bool(p_create)).to_lower()
+			query_params += "create=%s&" % str(bool(p_create)).to_lower()
 		if p_username != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_username
-			tmp = tmp
-			query_params += "username=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
+			query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
@@ -3750,7 +3742,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -3769,17 +3761,9 @@ class ApiClient extends RefCounted:
 		var urlpath : String = "/v2/account/authenticate/custom"
 		var query_params = ""
 		if p_create != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_create
-			tmp = tmp
-			query_params += "create=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "create=%s&" % str(bool(p_create)).to_lower()
+			query_params += "create=%s&" % str(bool(p_create)).to_lower()
 		if p_username != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_username
-			tmp = tmp
-			query_params += "username=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
+			query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
@@ -3788,7 +3772,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -3807,17 +3791,9 @@ class ApiClient extends RefCounted:
 		var urlpath : String = "/v2/account/authenticate/device"
 		var query_params = ""
 		if p_create != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_create
-			tmp = tmp
-			query_params += "create=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "create=%s&" % str(bool(p_create)).to_lower()
+			query_params += "create=%s&" % str(bool(p_create)).to_lower()
 		if p_username != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_username
-			tmp = tmp
-			query_params += "username=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
+			query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
@@ -3826,7 +3802,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -3845,17 +3821,9 @@ class ApiClient extends RefCounted:
 		var urlpath : String = "/v2/account/authenticate/email"
 		var query_params = ""
 		if p_create != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_create
-			tmp = tmp
-			query_params += "create=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "create=%s&" % str(bool(p_create)).to_lower()
+			query_params += "create=%s&" % str(bool(p_create)).to_lower()
 		if p_username != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_username
-			tmp = tmp
-			query_params += "username=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
+			query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
@@ -3864,7 +3832,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -3884,23 +3852,11 @@ class ApiClient extends RefCounted:
 		var urlpath : String = "/v2/account/authenticate/facebook"
 		var query_params = ""
 		if p_create != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_create
-			tmp = tmp
-			query_params += "create=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "create=%s&" % str(bool(p_create)).to_lower()
+			query_params += "create=%s&" % str(bool(p_create)).to_lower()
 		if p_username != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_username
-			tmp = tmp
-			query_params += "username=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
+			query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
 		if p_sync != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_sync
-			tmp = tmp
-			query_params += "sync=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "sync=%s&" % str(bool(p_sync)).to_lower()
+			query_params += "sync=%s&" % str(bool(p_sync)).to_lower()
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
@@ -3909,7 +3865,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -3928,17 +3884,9 @@ class ApiClient extends RefCounted:
 		var urlpath : String = "/v2/account/authenticate/facebookinstantgame"
 		var query_params = ""
 		if p_create != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_create
-			tmp = tmp
-			query_params += "create=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "create=%s&" % str(bool(p_create)).to_lower()
+			query_params += "create=%s&" % str(bool(p_create)).to_lower()
 		if p_username != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_username
-			tmp = tmp
-			query_params += "username=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
+			query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
@@ -3947,7 +3895,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -3966,17 +3914,9 @@ class ApiClient extends RefCounted:
 		var urlpath : String = "/v2/account/authenticate/gamecenter"
 		var query_params = ""
 		if p_create != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_create
-			tmp = tmp
-			query_params += "create=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "create=%s&" % str(bool(p_create)).to_lower()
+			query_params += "create=%s&" % str(bool(p_create)).to_lower()
 		if p_username != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_username
-			tmp = tmp
-			query_params += "username=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
+			query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
@@ -3985,7 +3925,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4004,17 +3944,9 @@ class ApiClient extends RefCounted:
 		var urlpath : String = "/v2/account/authenticate/google"
 		var query_params = ""
 		if p_create != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_create
-			tmp = tmp
-			query_params += "create=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "create=%s&" % str(bool(p_create)).to_lower()
+			query_params += "create=%s&" % str(bool(p_create)).to_lower()
 		if p_username != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_username
-			tmp = tmp
-			query_params += "username=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
+			query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
@@ -4023,7 +3955,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4043,23 +3975,11 @@ class ApiClient extends RefCounted:
 		var urlpath : String = "/v2/account/authenticate/steam"
 		var query_params = ""
 		if p_create != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_create
-			tmp = tmp
-			query_params += "create=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "create=%s&" % str(bool(p_create)).to_lower()
+			query_params += "create=%s&" % str(bool(p_create)).to_lower()
 		if p_username != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_username
-			tmp = tmp
-			query_params += "username=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
+			query_params += "username=%s&" % NakamaSerializer.escape_http(p_username)
 		if p_sync != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_sync
-			tmp = tmp
-			query_params += "sync=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "sync=%s&" % str(bool(p_sync)).to_lower()
+			query_params += "sync=%s&" % str(bool(p_sync)).to_lower()
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
@@ -4068,7 +3988,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4095,7 +4015,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4121,7 +4041,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4147,7 +4067,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4173,7 +4093,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4194,11 +4114,7 @@ class ApiClient extends RefCounted:
 		var urlpath : String = "/v2/account/link/facebook"
 		var query_params = ""
 		if p_sync != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_sync
-			tmp = tmp
-			query_params += "sync=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "sync=%s&" % str(bool(p_sync)).to_lower()
+			query_params += "sync=%s&" % str(bool(p_sync)).to_lower()
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
@@ -4206,7 +4122,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4232,7 +4148,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4258,7 +4174,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4284,7 +4200,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4310,7 +4226,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4333,7 +4249,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4360,7 +4276,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4386,7 +4302,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4412,7 +4328,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4438,7 +4354,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4464,7 +4380,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4490,7 +4406,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4516,7 +4432,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4542,7 +4458,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4568,7 +4484,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4594,17 +4510,9 @@ class ApiClient extends RefCounted:
 		if p_limit != null:
 			query_params += "limit=%d&" % p_limit
 		if p_forward != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_forward
-			tmp = tmp
-			query_params += "forward=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "forward=%s&" % str(bool(p_forward)).to_lower()
+			query_params += "forward=%s&" % str(bool(p_forward)).to_lower()
 		if p_cursor != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_cursor
-			tmp = tmp
-			query_params += "cursor=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
+			query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
@@ -4638,7 +4546,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4696,11 +4604,7 @@ class ApiClient extends RefCounted:
 		if p_state != null:
 			query_params += "state=%d&" % p_state
 		if p_cursor != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_cursor
-			tmp = tmp
-			query_params += "cursor=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
+			query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
@@ -4793,11 +4697,7 @@ class ApiClient extends RefCounted:
 		var urlpath : String = "/v2/friend/facebook"
 		var query_params = ""
 		if p_reset != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_reset
-			tmp = tmp
-			query_params += "reset=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "reset=%s&" % str(bool(p_reset)).to_lower()
+			query_params += "reset=%s&" % str(bool(p_reset)).to_lower()
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
@@ -4805,7 +4705,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4826,11 +4726,7 @@ class ApiClient extends RefCounted:
 		var urlpath : String = "/v2/friend/steam"
 		var query_params = ""
 		if p_reset != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_reset
-			tmp = tmp
-			query_params += "reset=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "reset=%s&" % str(bool(p_reset)).to_lower()
+			query_params += "reset=%s&" % str(bool(p_reset)).to_lower()
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
@@ -4838,7 +4734,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4863,33 +4759,17 @@ class ApiClient extends RefCounted:
 		var urlpath : String = "/v2/group"
 		var query_params = ""
 		if p_name != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_name
-			tmp = tmp
-			query_params += "name=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "name=%s&" % NakamaSerializer.escape_http(p_name)
+			query_params += "name=%s&" % NakamaSerializer.escape_http(p_name)
 		if p_cursor != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_cursor
-			tmp = tmp
-			query_params += "cursor=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
+			query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
 		if p_limit != null:
 			query_params += "limit=%d&" % p_limit
 		if p_lang_tag != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_lang_tag
-			tmp = tmp
-			query_params += "lang_tag=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "lang_tag=%s&" % NakamaSerializer.escape_http(p_lang_tag)
+			query_params += "lang_tag=%s&" % NakamaSerializer.escape_http(p_lang_tag)
 		if p_members != null:
 			query_params += "members=%d&" % p_members
 		if p_open != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_open
-			tmp = tmp
-			query_params += "open=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "open=%s&" % str(bool(p_open)).to_lower()
+			query_params += "open=%s&" % str(bool(p_open)).to_lower()
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
@@ -4923,7 +4803,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -4978,7 +4858,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -5208,11 +5088,7 @@ class ApiClient extends RefCounted:
 		if p_state != null:
 			query_params += "state=%d&" % p_state
 		if p_cursor != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_cursor
-			tmp = tmp
-			query_params += "cursor=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
+			query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
@@ -5246,7 +5122,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -5273,7 +5149,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -5300,7 +5176,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -5327,7 +5203,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -5354,7 +5230,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -5381,7 +5257,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -5465,17 +5341,9 @@ class ApiClient extends RefCounted:
 		if p_limit != null:
 			query_params += "limit=%d&" % p_limit
 		if p_cursor != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_cursor
-			tmp = tmp
-			query_params += "cursor=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
+			query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
 		if p_expiry != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_expiry
-			tmp = tmp
-			query_params += "expiry=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "expiry=%s&" % NakamaSerializer.escape_http(p_expiry)
+			query_params += "expiry=%s&" % NakamaSerializer.escape_http(p_expiry)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
@@ -5511,7 +5379,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -5539,11 +5407,7 @@ class ApiClient extends RefCounted:
 		if p_limit != null:
 			query_params += "limit=%d&" % p_limit
 		if p_expiry != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_expiry
-			tmp = tmp
-			query_params += "expiry=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "expiry=%s&" % NakamaSerializer.escape_http(p_expiry)
+			query_params += "expiry=%s&" % NakamaSerializer.escape_http(p_expiry)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
@@ -5578,27 +5442,15 @@ class ApiClient extends RefCounted:
 		if p_limit != null:
 			query_params += "limit=%d&" % p_limit
 		if p_authoritative != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_authoritative
-			tmp = tmp
-			query_params += "authoritative=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "authoritative=%s&" % str(bool(p_authoritative)).to_lower()
+			query_params += "authoritative=%s&" % str(bool(p_authoritative)).to_lower()
 		if p_label != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_label
-			tmp = tmp
-			query_params += "label=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "label=%s&" % NakamaSerializer.escape_http(p_label)
+			query_params += "label=%s&" % NakamaSerializer.escape_http(p_label)
 		if p_min_size != null:
 			query_params += "min_size=%d&" % p_min_size
 		if p_max_size != null:
 			query_params += "max_size=%d&" % p_max_size
 		if p_query != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_query
-			tmp = tmp
-			query_params += "query=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "query=%s&" % NakamaSerializer.escape_http(p_query)
+			query_params += "query=%s&" % NakamaSerializer.escape_http(p_query)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
@@ -5657,11 +5509,7 @@ class ApiClient extends RefCounted:
 		if p_limit != null:
 			query_params += "limit=%d&" % p_limit
 		if p_cacheable_cursor != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_cacheable_cursor
-			tmp = tmp
-			query_params += "cacheable_cursor=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "cacheable_cursor=%s&" % NakamaSerializer.escape_http(p_cacheable_cursor)
+			query_params += "cacheable_cursor=%s&" % NakamaSerializer.escape_http(p_cacheable_cursor)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
@@ -5687,17 +5535,9 @@ class ApiClient extends RefCounted:
 		urlpath = urlpath.replace("{id}", NakamaSerializer.escape_http(p_id))
 		var query_params = ""
 		if p_payload != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_payload
-			tmp = tmp
-			query_params += "payload=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "payload=%s&" % NakamaSerializer.escape_http(p_payload)
+			query_params += "payload=%s&" % NakamaSerializer.escape_http(p_payload)
 		if p_http_key != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_http_key
-			tmp = tmp
-			query_params += "http_key=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "http_key=%s&" % NakamaSerializer.escape_http(p_http_key)
+			query_params += "http_key=%s&" % NakamaSerializer.escape_http(p_http_key)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
@@ -5724,11 +5564,7 @@ class ApiClient extends RefCounted:
 		urlpath = urlpath.replace("{id}", NakamaSerializer.escape_http(p_id))
 		var query_params = ""
 		if p_http_key != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_http_key
-			tmp = tmp
-			query_params += "http_key=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "http_key=%s&" % NakamaSerializer.escape_http(p_http_key)
+			query_params += "http_key=%s&" % NakamaSerializer.escape_http(p_http_key)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "POST"
 		var headers = {}
@@ -5737,7 +5573,7 @@ class ApiClient extends RefCounted:
 			headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body).to_utf8_buffer()
+		content = JSON.stringify(p_body).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -5764,7 +5600,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -5790,7 +5626,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -5817,7 +5653,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -5844,7 +5680,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -5868,19 +5704,11 @@ class ApiClient extends RefCounted:
 		urlpath = urlpath.replace("{collection}", NakamaSerializer.escape_http(p_collection))
 		var query_params = ""
 		if p_user_id != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_user_id
-			tmp = tmp
-			query_params += "user_id=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "user_id=%s&" % NakamaSerializer.escape_http(p_user_id)
+			query_params += "user_id=%s&" % NakamaSerializer.escape_http(p_user_id)
 		if p_limit != null:
 			query_params += "limit=%d&" % p_limit
 		if p_cursor != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_cursor
-			tmp = tmp
-			query_params += "cursor=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
+			query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
@@ -5915,11 +5743,7 @@ class ApiClient extends RefCounted:
 		if p_limit != null:
 			query_params += "limit=%d&" % p_limit
 		if p_cursor != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_cursor
-			tmp = tmp
-			query_params += "cursor=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
+			query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
@@ -5962,11 +5786,7 @@ class ApiClient extends RefCounted:
 		if p_limit != null:
 			query_params += "limit=%d&" % p_limit
 		if p_cursor != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_cursor
-			tmp = tmp
-			query_params += "cursor=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
+			query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
@@ -6004,17 +5824,9 @@ class ApiClient extends RefCounted:
 		if p_limit != null:
 			query_params += "limit=%d&" % p_limit
 		if p_cursor != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_cursor
-			tmp = tmp
-			query_params += "cursor=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
+			query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
 		if p_expiry != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_expiry
-			tmp = tmp
-			query_params += "expiry=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "expiry=%s&" % NakamaSerializer.escape_http(p_expiry)
+			query_params += "expiry=%s&" % NakamaSerializer.escape_http(p_expiry)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
@@ -6050,7 +5862,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -6079,7 +5891,7 @@ class ApiClient extends RefCounted:
 		headers["Authorization"] = header
 
 		var content : PackedByteArray
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
 
 		var result = await _http_adapter.send_async(method, uri, headers, content)
 		if result is NakamaException:
@@ -6133,11 +5945,7 @@ class ApiClient extends RefCounted:
 		if p_limit != null:
 			query_params += "limit=%d&" % p_limit
 		if p_expiry != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_expiry
-			tmp = tmp
-			query_params += "expiry=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "expiry=%s&" % NakamaSerializer.escape_http(p_expiry)
+			query_params += "expiry=%s&" % NakamaSerializer.escape_http(p_expiry)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}
@@ -6210,11 +6018,7 @@ class ApiClient extends RefCounted:
 		if p_state != null:
 			query_params += "state=%d&" % p_state
 		if p_cursor != null:
-			# Work around issue #53115 / #56217
-			var tmp = p_cursor
-			tmp = tmp
-			query_params += "cursor=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
+			query_params += "cursor=%s&" % NakamaSerializer.escape_http(p_cursor)
 		var uri = "%s%s%s" % [_base_uri, urlpath, "?" + query_params if query_params else ""]
 		var method = "GET"
 		var headers = {}

--- a/addons/com.heroiclabs.nakama/api/NakamaRTMessage.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaRTMessage.gd
@@ -448,9 +448,9 @@ class PartyPromote extends NakamaAsyncResult:
 	# Party ID to promote a new leader for.
 	var party_id : String
 	# The presence of an existing party member to promote as the new leader.
-	var presence
+	var presence : NakamaRTAPI.UserPresence
 
-	func _init(p_id : String, p_presence):
+	func _init(p_id : String, p_presence : NakamaRTAPI.UserPresence):
 		party_id = p_id
 		presence = p_presence
 
@@ -473,9 +473,9 @@ class PartyAccept extends NakamaAsyncResult:
 	# Party ID to accept a join request for.
 	var party_id : String
 	# The presence to accept as a party member.
-	var presence
+	var presence : NakamaRTAPI.UserPresence
 
-	func _init(p_id : String, p_presence):
+	func _init(p_id : String, p_presence : NakamaRTAPI.UserPresence):
 		party_id = p_id
 		presence = p_presence
 
@@ -498,9 +498,9 @@ class PartyRemove extends NakamaAsyncResult:
 	# Party ID to remove/reject from.
 	var party_id : String
 	# The presence to remove or reject.
-	var presence
+	var presence : NakamaRTAPI.UserPresence
 
-	func _init(p_id : String, p_presence):
+	func _init(p_id : String, p_presence : NakamaRTAPI.UserPresence):
 		party_id = p_id
 		presence = p_presence
 

--- a/addons/com.heroiclabs.nakama/client/NakamaClient.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaClient.gd
@@ -3,7 +3,7 @@ extends RefCounted
 # A client for the API in Nakama server.
 class_name NakamaClient
 
-var ChannelType = NakamaRTMessage.ChannelJoin.ChannelType
+const ChannelType = NakamaRTMessage.ChannelJoin.ChannelType
 
 # The host address of the server. Defaults to "127.0.0.1".
 var _host
@@ -779,8 +779,7 @@ func read_storage_objects_async(p_session : NakamaSession, p_ids : Array): # -> 
 func rpc_async(p_session : NakamaSession, p_id : String, p_payload = null): # -> NakamaAPI.ApiRpc:
 	if p_payload == null:
 		return await _api_client.rpc_func2_async(p_session.token, p_id)
-	# Use .call() as a work around for issue #53115 / #56217
-	return await _api_client.rpc_func_async.call(p_session.token, p_id, p_payload)
+	return await _api_client.rpc_func_async(p_session.token, p_id, p_payload)
 
 # Execute a function on the server without a session.
 # This function is usually used with server side code. DO NOT USE client side.
@@ -791,8 +790,7 @@ func rpc_async(p_session : NakamaSession, p_id : String, p_payload = null): # ->
 func rpc_async_with_key(p_http_key : String, p_id : String, p_payload = null): # -> NakamaAPI.ApiRpc:
 	if p_payload == null:
 		return await _api_client.rpc_func2_async("", p_id, null, p_http_key)
-	# Use .call() as a work around for issue #53115 / #56217
-	return await _api_client.rpc_func_async.call("", p_id, p_payload, p_http_key)
+	return await _api_client.rpc_func_async("", p_id, p_payload, p_http_key)
 
 # Log out a session which optionally invalidates the authorization and/or refresh tokens.
 # @param p_session - The session of the user.

--- a/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
@@ -124,7 +124,7 @@ class AsyncRequest:
 			else:
 				error = str(parsed)
 			if typeof(error) == TYPE_DICTIONARY:
-				error = json.stringify(error)
+				error = JSON.stringify(error)
 			logger.debug("Request %d returned response code: %d, RPC code: %d, error: %s" % [
 				id, response_code, code, error
 			])

--- a/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
+++ b/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
@@ -3,7 +3,7 @@ extends RefCounted
 # A socket to interact with Nakama server.
 class_name NakamaSocket
 
-var ChannelType = NakamaRTMessage.ChannelJoin.ChannelType
+const ChannelType = NakamaRTMessage.ChannelJoin.ChannelType
 
 # Emitted when a socket is closed.
 signal closed()
@@ -288,12 +288,11 @@ func _send_async(p_message, p_parse_type = NakamaAsyncResult, p_ns = NakamaRTAPI
 
 	_requests[id] = AsyncRequest.new(id, p_parse_type, p_ns, p_result_key)
 
-	var json = JSON.new()
-	var json_str := json.stringify({
+	var json := JSON.stringify({
 		"cid": id,
 		msg: p_message.serialize()
 	})
-	var err = _adapter.send(json_str.to_utf8_buffer())
+	var err = _adapter.send(json.to_utf8_buffer())
 	if err != OK:
 		call_deferred("_cancel_request", id)
 	return _requests[id]
@@ -332,7 +331,7 @@ func connect_async(p_session : NakamaSession, p_appear_online : bool = false, p_
 # Returns a task which resolves to a matchmaker ticket object.
 func add_matchmaker_async(p_query : String = "*", p_min_count : int = 2, p_max_count : int = 8,
 		p_string_props : Dictionary = {}, p_numeric_props : Dictionary = {},
-		p_count_multiple : int = 0): # -> NakamaRTAPI.MatchmakerTicket
+		p_count_multiple : int = 0) -> NakamaRTAPI.MatchmakerTicket:
 	return await _send_async(
 		NakamaRTMessage.MatchmakerAdd.new(p_query, p_min_count, p_max_count, p_string_props, p_numeric_props, p_count_multiple),
 		NakamaRTAPI.MatchmakerTicket
@@ -348,7 +347,7 @@ func create_match_async(p_name : String = ''):
 # @param p_user_ids - The IDs of users.
 # @param p_usernames - The usernames of the users.
 # Returns a task which resolves to the current statuses for the users.
-func follow_users_async(p_ids : PackedStringArray, p_usernames : PackedStringArray): # -> NakamaRTAPI.Status
+func follow_users_async(p_ids : PackedStringArray, p_usernames : PackedStringArray) -> NakamaRTAPI.Status:
 	return await _send_async(NakamaRTMessage.StatusFollow.new(p_ids, p_usernames), NakamaRTAPI.Status).completed
 
 # Join a chat channel on the server.
@@ -357,7 +356,7 @@ func follow_users_async(p_ids : PackedStringArray, p_usernames : PackedStringArr
 # @param p_persistence - If chat messages should be stored.
 # @param p_hidden - If the current user should be hidden on the channel.
 # Returns a task which resolves to a chat channel object.
-func join_chat_async(p_target : String, p_type : int, p_persistence : bool = false, p_hidden : bool = false): # -> NakamaRTAPI.Channel
+func join_chat_async(p_target : String, p_type : int, p_persistence : bool = false, p_hidden : bool = false) -> NakamaRTAPI.Channel:
 	return await _send_async(
 		NakamaRTMessage.ChannelJoin.new(p_target, p_type, p_persistence, p_hidden),
 		NakamaRTAPI.Channel
@@ -416,13 +415,13 @@ func remove_matchmaker_async(p_ticket : String) -> NakamaAsyncResult:
 # @param p_func_id - The ID of the function to execute.
 # @param p_payload - An (optional) String payload to send to the server.
 # Returns a task which resolves to the RPC function response object.
-func rpc_async(p_func_id : String, p_payload = null): # -> NakamaAPI.ApiRpc
+func rpc_async(p_func_id : String, p_payload = null) -> NakamaAPI.ApiRpc:
 	var payload = p_payload
 	match typeof(p_payload):
 		TYPE_NIL, TYPE_STRING:
 			pass
 		_:
-			payload = JSON.new().stringify(p_payload)
+			payload = JSON.stringify(p_payload)
 	return await _send_async(NakamaAPI.ApiRpc.create(NakamaAPI, {
 		"id": p_func_id,
 		"payload": payload
@@ -477,7 +476,7 @@ func unfollow_users_async(p_ids : PackedStringArray):
 # Returns a task which resolves to an acknowledgement of the updated message.
 func update_chat_message_async(p_channel_id : String, p_message_id : String, p_content : Dictionary):
 	return await _send_async(
-		NakamaRTMessage.ChannelMessageUpdate.new(p_channel_id, p_message_id, JSON.new().stringify(p_content)),
+		NakamaRTMessage.ChannelMessageUpdate.new(p_channel_id, p_message_id, JSON.stringify(p_content)),
 		NakamaRTAPI.ChannelMessageAck
 	).completed
 
@@ -493,7 +492,7 @@ func update_status_async(p_status : String):
 # Returns a task which resolves to the acknowledgement of the chat message write.
 func write_chat_message_async(p_channel_id : String, p_content : Dictionary):
 	return await _send_async(
-		NakamaRTMessage.ChannelMessageSend.new(p_channel_id, JSON.new().stringify(p_content)),
+		NakamaRTMessage.ChannelMessageSend.new(p_channel_id, JSON.stringify(p_content)),
 		NakamaRTAPI.ChannelMessageAck
 	).completed
 
@@ -501,7 +500,7 @@ func write_chat_message_async(p_channel_id : String, p_content : Dictionary):
 # @param p_party_id - The party ID to accept the join request for.
 # @param p_presence - The presence to accept as a party member.
 # Returns a task to represent the asynchronous operation.
-func accept_party_member_async(p_party_id : String, p_presence):
+func accept_party_member_async(p_party_id : String, p_presence : NakamaRTAPI.UserPresence):
 	return await _send_async(NakamaRTMessage.PartyAccept.new(p_party_id, p_presence)).completed
 
 # Begin matchmaking as a party.
@@ -533,7 +532,7 @@ func close_party_async(p_party_id : String):
 # @param p_open - Whether or not the party will require join requests to be approved by the party leader.
 # @param p_max_size - Maximum number of party members. This maximum does not include the party leader.
 # Returns a task to represent the asynchronous operation.
-func create_party_async(p_open : bool, p_max_size : int): # -> NakamaRTAPI.Party
+func create_party_async(p_open : bool, p_max_size : int) -> NakamaRTAPI.Party:
 	return await _send_async(
 		NakamaRTMessage.PartyCreate.new(p_open, p_max_size),
 		NakamaRTAPI.Party
@@ -554,7 +553,7 @@ func leave_party_async(p_party_id : String):
 # Request a list of pending join requests for a party.
 # @param p_party_id - Party ID.
 # Returns a task which resolves to a list of all party join requests.
-func list_party_join_requests_async(p_party_id : String): # -> NakamaRTAPI.PartyJoinRequest
+func list_party_join_requests_async(p_party_id : String) -> NakamaRTAPI.PartyJoinRequest:
 	return await _send_async(
 		NakamaRTMessage.PartyJoinRequestList.new(p_party_id),
 		NakamaRTAPI.PartyJoinRequest).completed
@@ -563,7 +562,7 @@ func list_party_join_requests_async(p_party_id : String): # -> NakamaRTAPI.Party
 # @param p_party_id - Party ID.
 # @param p_party_member - The presence of an existing party member to promote as the new leader.
 # Returns a which represents the asynchronous operation.
-func promote_party_member(p_party_id : String, p_party_member):
+func promote_party_member(p_party_id : String, p_party_member : NakamaRTAPI.UserPresence):
 	return await _send_async(NakamaRTMessage.PartyPromote.new(p_party_id, p_party_member)).completed
 
 # Cancel a party matchmaking process using a ticket.
@@ -577,7 +576,7 @@ func remove_matchmaker_party_async(p_party_id : String, p_ticket : String):
 # @param p_party_id - Party ID to remove/reject from.
 # @param p_presence - The presence to remove or reject.
 # Returns a task which represents the asynchronous operation.
-func remove_party_member_async(p_party_id : String, p_presence):
+func remove_party_member_async(p_party_id : String, p_presence : NakamaRTAPI.UserPresence):
 	return await _send_async(NakamaRTMessage.PartyRemove.new(p_party_id, p_presence)).completed
 
 # Send data to a party.

--- a/addons/com.heroiclabs.nakama/utils/NakamaMultiplayerBridge.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaMultiplayerBridge.gd
@@ -232,10 +232,8 @@ func _host_add_peer(presence) -> void:
 	var peer_id = _generate_id(presence.session_id)
 	_map_id_to_session(peer_id, presence.session_id)
 
-	var json = JSON.new()
-
 	# Tell them we are the host.
-	_nakama_socket.send_match_state_async(_match_id, meta_op_code, json.stringify({
+	_nakama_socket.send_match_state_async(_match_id, meta_op_code, JSON.stringify({
 		type = MetaMessageType.CLAIM_HOST,
 	}), [presence])
 
@@ -244,14 +242,14 @@ func _host_add_peer(presence) -> void:
 		var other_session_id = _id_map[other_peer_id]
 		if other_session_id == presence.session_id or other_session_id == _my_session_id:
 			continue
-		_nakama_socket.send_match_state_async(_match_id, meta_op_code, json.stringify({
+		_nakama_socket.send_match_state_async(_match_id, meta_op_code, JSON.stringify({
 			type = MetaMessageType.ASSIGN_PEER_ID,
 			session_id = other_session_id,
 			peer_id = other_peer_id,
 		}), [presence])
 
 	# Assign them a peer_id (tell everyone about it).
-	_nakama_socket.send_match_state_async(_match_id, meta_op_code, json.stringify({
+	_nakama_socket.send_match_state_async(_match_id, meta_op_code, JSON.stringify({
 		type = MetaMessageType.ASSIGN_PEER_ID,
 		session_id = presence.session_id,
 		peer_id = peer_id,

--- a/codegen/main.go
+++ b/codegen/main.go
@@ -259,17 +259,9 @@ class ApiClient extends RefCounted:
                 {{- if eq $parameter.Type "integer" }}
 			query_params += "{{- $snakecase }}=%d&" % {{ $argument }}
                 {{- else if eq $parameter.Type "string" }}
-			# Work around issue #53115 / #56217
-			var tmp = {{ $argument }}
-			tmp = tmp
-			query_params += "{{- $snakecase }}=%s&" % NakamaSerializer.escape_http(tmp)
-			#query_params += "{{- $snakecase }}=%s&" % NakamaSerializer.escape_http({{ $argument }})
+			query_params += "{{- $snakecase }}=%s&" % NakamaSerializer.escape_http({{ $argument }})
                 {{- else if eq $parameter.Type "boolean" }}
-			# Work around issue #53115 / #56217
-			var tmp = {{ $argument }}
-			tmp = tmp
-			query_params += "{{- $snakecase }}=%s&" % str(bool(tmp)).to_lower()
-			#query_params += "{{- $snakecase }}=%s&" % str(bool({{ $argument }})).to_lower()
+			query_params += "{{- $snakecase }}=%s&" % str(bool({{ $argument }})).to_lower()
                 {{- else if eq $parameter.Type "array" }}
 			for elem in {{ $argument }}:
 				query_params += "{{- $snakecase }}=%s&" % elem
@@ -305,9 +297,9 @@ class ApiClient extends RefCounted:
             {{- $argument := $parameter.Name | prependParameter }}
             {{- if eq $parameter.In "body" }}
                 {{- if eq $parameter.Schema.Type "string" }}
-		content = JSON.new().stringify(p_body).to_utf8_buffer()
+		content = JSON.stringify(p_body).to_utf8_buffer()
                 {{- else }}
-		content = JSON.new().stringify(p_body.serialize()).to_utf8_buffer()
+		content = JSON.stringify(p_body.serialize()).to_utf8_buffer()
                 {{- end }}
             {{- end }}
             {{- end }}

--- a/test_suite/run_tests.sh
+++ b/test_suite/run_tests.sh
@@ -3,7 +3,7 @@
 END_STRING="======= TESTS END"
 PROJECT_PATH="test_suite/"
 GODOT_BIN="test_suite/bin/godot.elf"
-OUT=`$GODOT_BIN --debug --path test_suite/ -s res://runner.gd`
+OUT=`$GODOT_BIN --headless --debug --path test_suite/ -s res://runner.gd`
 RUN=`echo $OUT | grep "$END_STRING"`
 RES=`echo $OUT | grep FAILURE`
 

--- a/test_suite/tester.tscn
+++ b/test_suite/tester.tscn
@@ -7,4 +7,6 @@ layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 script = ExtResource("1")

--- a/test_suite/tests/client_test.gd
+++ b/test_suite/tests/client_test.gd
@@ -12,15 +12,13 @@ func setup():
 	if assert_false(update.is_exception()):
 		return
 	# GET
-	var account = await client.get_account_async(session)
-	#var account : NakamaAPI.ApiAccount = await client.get_account_async(session)
+	var account : NakamaAPI.ApiAccount = await client.get_account_async(session)
 	if assert_false(account.is_exception()):
 		return
 	if assert_cond(account.user.username == username):
 		return
 	# POST - DELETE
-	#var group : NakamaAPI.ApiGroup = await client.create_group_async(session, "MyGroupName3")
-	var group = await client.create_group_async(session, "MyGroupName3")
+	var group : NakamaAPI.ApiGroup = await client.create_group_async(session, "MyGroupName3")
 	if assert_false(group.is_exception()):
 		return
 	var delete = await client.delete_group_async(session, group.id)

--- a/test_suite/tests/socket_multi_test.gd
+++ b/test_suite/tests/socket_multi_test.gd
@@ -34,10 +34,10 @@ func setup():
 		return
 
 	# Join room
-	var room1 = await socket1.join_chat_async("MyRoom", socket1.ChannelType.Room)
+	var room1 = await socket1.join_chat_async("MyRoom", NakamaSocket.ChannelType.Room)
 	if assert_false(room1.is_exception()):
 		return
-	var room2 = await socket2.join_chat_async("MyRoom", socket2.ChannelType.Room)
+	var room2 = await socket2.join_chat_async("MyRoom", NakamaSocket.ChannelType.Room)
 	if assert_false(room2.is_exception()):
 		return
 
@@ -54,21 +54,19 @@ func setup():
 		return
 
 func _on_socket1_message(msg):
-	var json = JSON.new()
-	if assert_equal(msg.content, json.stringify(content)):
+	if assert_equal(msg.content, JSON.stringify(content)):
 		return
 	got_msg = true
 	check_end()
 
 func _on_socket1_matchmaker_matched(p_matchmaker_matched):
-	var json = JSON.new()
-	if assert_equal(json.stringify(p_matchmaker_matched.users[0].string_properties), json.stringify(match_string_props)):
+	if assert_equal(JSON.stringify(p_matchmaker_matched.users[0].string_properties), JSON.stringify(match_string_props)):
 		return
-	if assert_equal(json.stringify(p_matchmaker_matched.users[0].numeric_properties), json.stringify(match_numeric_props)):
+	if assert_equal(JSON.stringify(p_matchmaker_matched.users[0].numeric_properties), JSON.stringify(match_numeric_props)):
 		return
-	if assert_equal(json.stringify(p_matchmaker_matched.users[1].string_properties), json.stringify(match_string_props)):
+	if assert_equal(JSON.stringify(p_matchmaker_matched.users[1].string_properties), JSON.stringify(match_string_props)):
 		return
-	if assert_equal(json.stringify(p_matchmaker_matched.users[1].numeric_properties), json.stringify(match_numeric_props)):
+	if assert_equal(JSON.stringify(p_matchmaker_matched.users[1].numeric_properties), JSON.stringify(match_numeric_props)):
 		return
 	got_match = true
 	check_end()

--- a/test_suite/tests/socket_party_test.gd
+++ b/test_suite/tests/socket_party_test.gd
@@ -49,10 +49,9 @@ func setup():
 	if assert_false(join.is_exception()):
 		return
 
-func _on_party_join_request(party_join_request):
+func _on_party_join_request(party_join_request : NakamaRTAPI.PartyJoinRequest):
 	prints("_on_party_join_request", party_join_request)
-	#var requests : NakamaRTAPI.PartyJoinRequest = await socket1.list_party_join_requests_async(party_join_request.party_id)
-	var requests = await socket1.list_party_join_requests_async(party_join_request.party_id)
+	var requests : NakamaRTAPI.PartyJoinRequest = await socket1.list_party_join_requests_async(party_join_request.party_id)
 	if assert_false(requests.is_exception()):
 		return
 	if assert_cond(requests.presences.size() == 1):
@@ -67,20 +66,20 @@ func _on_party(party):
 func _on_party_close(party_close):
 	prints("_on_party_close", party_close)
 
-func _on_party_data(data):
+func _on_party_data(data : NakamaRTAPI.PartyData):
 	prints("_on_party_data", data)
 	var left = await socket1.leave_party_async(data.party_id)
 	if assert_false(left.is_exception()):
 		return
 
-func _on_party_leader(party_leader):
+func _on_party_leader(party_leader : NakamaRTAPI.PartyLeader):
 	prints("_on_party_leader", party_leader)
 	var ticket = await socket2.add_matchmaker_party_async(party_leader.party_id)
 	if assert_false(ticket.is_exception()):
 		return
 	_on_party_ticket(ticket)
 
-func _on_party_ticket(ticket):
+func _on_party_ticket(ticket : NakamaRTAPI.PartyMatchmakerTicket):
 	prints("_on_party_ticket", ticket)
 	var removed = await socket2.remove_matchmaker_party_async(ticket.party_id, ticket.ticket)
 	if assert_false(removed.is_exception()):
@@ -89,7 +88,7 @@ func _on_party_ticket(ticket):
 	if assert_false(sent.is_exception()):
 		return
 
-func _on_party_presence(party_presence):
+func _on_party_presence(party_presence : NakamaRTAPI.PartyPresenceEvent):
 	prints("_on_party_presence", party_presence)
 	var left = party_presence.leaves.size() == 1
 	if left:

--- a/test_suite/tests/storage_test.gd
+++ b/test_suite/tests/storage_test.gd
@@ -18,15 +18,16 @@ func setup():
 		NakamaWriteStorageObject.new(COLLECTION, K1, 1, 1, to_json(V1), ""),
 		NakamaWriteStorageObject.new(COLLECTION, K2, 1, 1, to_json(V2), "")
 	]
-	var write = await client.write_storage_objects_async(session, objs)
+	var write : NakamaAPI.ApiStorageObjectAcks = await client.write_storage_objects_async(session, objs)
 	if assert_false(write.is_exception()):
 		return
 
 	var objs_ids = []
 	for a in write.acks:
+		#var obj : NakamaAPI.ApiStorageObjectAck = a
 		objs_ids.append(NakamaStorageObjectId.new(a.collection, a.key, a.user_id, a.version))
 
-	var read = await client.read_storage_objects_async(session, objs_ids)
+	var read : NakamaAPI.ApiStorageObjects = await client.read_storage_objects_async(session, objs_ids)
 	if assert_false(read.is_exception()):
 		return
 	if assert_equal(read.objects.size(), 2):
@@ -44,7 +45,7 @@ func setup():
 		return
 
 	# Confirm that one was deleted
-	var read2 = await client.read_storage_objects_async(session, objs_ids)
+	var read2 : NakamaAPI.ApiStorageObjects = await client.read_storage_objects_async(session, objs_ids)
 	if assert_false(read2.is_exception()):
 		return
 	if assert_equal(read2.objects.size(), 1):
@@ -62,8 +63,7 @@ func _process(_delta):
 	assert_time(3)
 
 func to_json(value) -> String:
-	var json = JSON.new()
-	return json.stringify(value)
+	return JSON.stringify(value)
 
 func parse_json(value):
 	var json = JSON.new()


### PR DESCRIPTION
In the initial port to Godot 4, I needed to use a whole bunch of hacks and workarounds, due to bugs (mostly in GDScript and mostly concerning typehints). As far as I can tell, all those issues are fixed now (as of Godot 4.0-beta12)!

So, this PR finally removes all the hacks and workarounds :-)

A side-effect of this is that the code for Godot 3 and 4 is now slightly closer together, which will make porting changes between the two versions a little easier.