### PR TITLE
[godot-4] Synchronize CHANGELOG.md with the Godot 3 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 
 - Fix NakamaSocket.add_matchmaker_party_async() and the tests for it
 - Fix MatchData.op_code type in schema to TYPE_INT
+- Fix circular reference in Nakama singleton to itself
 
 ### Added
 


### PR DESCRIPTION
In preparation for releasing the Godot 4 version of the addon, this just synchronizes the CHANGELOG.md with the Godot 3 version. Not sure how they got out of sync - I must have accidentally left out the CHANGELOG.md change when porting one of the PRs to Godot 4.