### PR TITLE
fix: correct call to request for beta17

### DIFF
--- a/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
@@ -68,7 +68,7 @@ class AsyncRequest:
 		return await make_request()
 
 	func make_request():
-		var err = request.request(uri, headers, true, method, body.get_string_from_utf8())
+		var err = request.request(uri, headers, method, body.get_string_from_utf8())
 		if err != OK:
 			await request.get_tree().process_frame
 			result = HTTPRequest.RESULT_CANT_CONNECT


### PR DESCRIPTION
Updates call to `HTTPRequest.request` to be compatible with Godot beta 17