### PR TITLE
Godot 4 RC3 Type check and return fixes

### DIFF
--- a/addons/com.heroiclabs.nakama/utils/NakamaAsyncResult.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaAsyncResult.gd
@@ -27,7 +27,7 @@ func _to_string():
 	return "NakamaAsyncResult<>"
 
 static func _safe_ret(p_obj, p_type : GDScript):
-	if p_obj is p_type:
+	if is_instance_of(p_obj, p_type):
 		return p_obj # Correct type
 	elif p_obj is NakamaException:
 		return p_type.new(p_obj) # It's an exception. Incapsulate it

--- a/addons/com.heroiclabs.nakama/utils/NakamaMultiplayerPeer.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaMultiplayerPeer.gd
@@ -31,7 +31,7 @@ func _get_packet_mode() -> int:
 func _get_packet_channel() -> int:
 	return 0
 
-func _put_packet_script(p_buffer: PackedByteArray) -> int:
+func _put_packet_script(p_buffer: PackedByteArray) -> Error:
 	packet_generated.emit(_target_id, p_buffer)
 	return OK
 


### PR DESCRIPTION
Godot introduced a new function `is_instance_of` to check if an Object is a type that is not known at runtime. This breaks functionality using `is` to check types not known at runtime. `_put_packet_script` function has also been updated to return `Error` instead of `int` to match parent function.