### PR TITLE
Fix byte array null error in GodotHttpAdapter

### DIFF
--- a/addons/com.heroiclabs.nakama/mono-utils/GodotHttpAdapter.cs
+++ b/addons/com.heroiclabs.nakama/mono-utils/GodotHttpAdapter.cs
@@ -69,7 +69,7 @@ namespace Nakama {
                 index++;
             }
 
-            string body_string = System.Text.Encoding.UTF8.GetString(body);
+            string body_string = body != null ? System.Text.Encoding.UTF8.GetString(body) : "";
 
             AddChild(req);
             req.Request(uri.ToString(), headers_array, true, godot_method, body_string);


### PR DESCRIPTION
Changed `GodotHttpAdapter.SendAsync` to send an empty body string if the byte array is null. Originally it would throw an error because `System.Text.Encoding` cannot encode a null byte array.

Fixes #161 