### PR TITLE
Incorrect access of sub-class in a script.

### DIFF
--- a/addons/com.heroiclabs.nakama/utils/NakamaSerializer.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaSerializer.gd
@@ -60,7 +60,7 @@ static func serialize(p_obj : Object) -> Dictionary:
 	return out
 
 static func deserialize(p_ns : GDScript, p_cls_name : String, p_dict : Dictionary) -> Object:
-	var cls : GDScript = p_ns.get(p_cls_name)
+	var cls : GDScript = p_ns.get_script_constant_map().get(p_cls_name)
 	var schema = cls.get("_SCHEMA")
 	if schema == null:
 		return NakamaException.new() # No schema defined


### PR DESCRIPTION
The sub-class names of a script aren't listed as properties of the script rather as constants. Therefore, we can get the class-names defined in the script from the constants list (which is defined in a map/dictionary form).

This was a bug that didn't deserialize the dictionary properly and pack it into the object and so the object returned was empty.