### PR TITLE
Incorrect way of type checking.

### DIFF
--- a/addons/com.heroiclabs.nakama/utils/NakamaAsyncResult.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaAsyncResult.gd
@@ -27,7 +27,7 @@ func _to_string():
 	return "NakamaAsyncResult<>"
 
 static func _safe_ret(p_obj, p_type : GDScript):
-	if p_obj is p_type:
+	if p_obj.get_class() == p_type.get_instance_base_type():
 		return p_obj # Correct type
 	elif p_obj is NakamaException:
 		return p_type.new(p_obj) # It's an exception. Incapsulate it


### PR DESCRIPTION
Checking the type of the object in this way is not supported in Godot 4 as it errors out with "Could not find type "p_type" in the current scope.", since Godot is considering the parameter `p_type` as a pre-defined or defined name of a class such as `Node`, `Object`, `GDScript`, etc.

Therefore, we can check the type of `p_obj` by getting the class as string and seeing if it is equal to base type of `p_type`.