### PR TITLE
Fix JSON error typo in NakamaHTTPAdapter

### DIFF
--- a/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
@@ -105,7 +105,7 @@ class AsyncRequest:
 
 		var json_error = json.parse(response_body.get_string_from_utf8())
 		if json_error != OK:
-			logger.debug("Unable to parse request %d response. JSON error: %d, JSON error message: %d, response code: %d" % [
+			logger.debug("Unable to parse request %d response. JSON error: %d, JSON error message: %s, response code: %d" % [
 				id, json_error, json.get_error_message(), response_code
 			])
 			return NakamaException.new("Failed to decode JSON response", response_code)

--- a/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
@@ -105,8 +105,8 @@ class AsyncRequest:
 
 		var json_error = json.parse(response_body.get_string_from_utf8())
 		if json_error != OK:
-			logger.debug("Unable to parse request %d response. JSON error: %d, response code: %d" % [
-				id, json.error, response_code
+			logger.debug("Unable to parse request %d response. JSON error: %d, JSON error message: %d, response code: %d" % [
+				id, json_error, json.get_error_message(), response_code
 			])
 			return NakamaException.new("Failed to decode JSON response", response_code)
 


### PR DESCRIPTION
I've reported this on the forums a while ago, but there seems to have been a small typo in the `NakamaHTTPAdapter.AsyncRequest` `parse_result()` method,
where it should have been
```gdscript
json_error
```
instead of 
```
json.error
```
which resulted in an error message.

The reason the issue occurred is because the `json.parse()` method worked differently in Godot 3.x, and the code probably wasn't updated when migrating to Godot 4.

I've also included the JSON error message in the logger text to make debugging a bit easier.