### PR TITLE
Added exceptions for ids of wrong type.

### DIFF
--- a/addons/com.heroiclabs.nakama/client/NakamaClient.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaClient.gd
@@ -367,7 +367,7 @@ func delete_storage_objects_async(p_session : NakamaSession, p_ids : Array) -> N
 	var ids : Array = []
 	for id in p_ids:
 		if not id is NakamaStorageObjectId:
-			continue # TODO Exceptions
+			return NakamaAsyncResult.new(NakamaException.new("Id is not a NakamaStorageObjectId: %s" % id))
 		var obj_id : NakamaStorageObjectId = id
 		ids.append(obj_id.as_delete().serialize())
 	return await _api_client.delete_storage_objects_async(p_session,
@@ -771,7 +771,7 @@ func read_storage_objects_async(p_session : NakamaSession, p_ids : Array): # -> 
 	var ids = []
 	for id in p_ids:
 		if not id is NakamaStorageObjectId:
-			continue # TODO Exceptions
+			return NakamaAsyncResult.new(NakamaException.new("Id is not a NakamaStorageObjectId: %s" % id))
 		var obj_id : NakamaStorageObjectId = id
 		ids.append(obj_id.as_read().serialize())
 	return await _api_client.read_storage_objects_async(p_session,
@@ -1042,7 +1042,7 @@ func write_storage_objects_async(p_session : NakamaSession, p_objects : Array): 
 	var writes : Array = []
 	for obj in p_objects:
 		if not obj is NakamaWriteStorageObject:
-			continue # TODO Exceptions
+			return NakamaAsyncResult.new(NakamaException.new("Obj is not a NakamaWriteStorageObject: %s" % obj))
 		var write_obj : NakamaWriteStorageObject = obj
 		writes.append(write_obj.as_write().serialize())
 	return await _api_client.write_storage_objects_async(p_session,


### PR DESCRIPTION
After it failed silently on me today because I just sent a `String` id instead of the `NakamaStorageObjectId` I added these missing exceptions. I thought about gathering all incorrect ids of the input array but throwing an exception only for the first incorrect one and aborting the operation should suffice as the items are most likely all of the same (incorrect) type.