### PR TITLE
Suggestion: Add GRPC status codes as constants

### DIFF
--- a/addons/com.heroiclabs.nakama/utils/NakamaException.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaException.gd
@@ -4,6 +4,25 @@ extends RefCounted
 # Usually contains at least an error message.
 class_name NakamaException
 
+enum { GRPC_OK,
+       GRPC_CANCELED,
+       GRPC_UNKNOWN,
+       GRPC_INVALID_ARGUMENT,
+       GRPC_DEADLINE_EXCEEDED,
+       GRPC_NOT_FOUND,
+       GRPC_ALREADY_EXISTS,
+       GRPC_PERMISSION_DENIED,
+       GRPC_RESOURCE_EXHAUSTED,
+       GRPC_FAILED_PRECONDITION,
+       GRPC_ABORTED,
+       GRPC_OUT_OF_RANGE,
+       GRPC_UNIMPLEMENTED,
+       GRPC_INTERNAL,
+       GRPC_UNAVAILABLE,
+       GRPC_DATA_LOSS,
+       GRPC_UNAUTHENTICATED
+}
+
 var _status_code : int = -1
 var status_code : int:
 	set(v):


### PR DESCRIPTION
While working with server side Nakama RPCs I found myself using the [suggested grpc status codes](https://heroiclabs.com/docs/nakama/server-framework/lua-runtime/#returning-errors-to-the-client) and I added them to a constants file as they were not available anywhere before.

I suggest adding them to the `NakamaException` or alternatively to the `Nakama` autoload for easy access when working with gRPC. A named enum `GRPC` could also be used instead of prefixing it to all constants but this is the most 'Godot-way', I think.

Additionally there is the field `status_code` on `NakamaException`. I found it somewhat confusing in the beginning as it is not clear from the documentation whether that is http-status code or Godot errors. In Godot the http codes are available as `RESPONSE_*` constants - would it make sense to rename the property to `response_code`?