### PR TITLE
Fixes incorrect NakamaMultiplayerBridge._match_state assignment

### DIFF
--- a/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
+++ b/addons/com.heroiclabs.nakama/socket/NakamaSocket.gd
@@ -155,7 +155,7 @@ func _init(p_adapter : NakamaSocketAdapter,
 	_free_adapter = p_free_adapter
 	_adapter.closed.connect(self._closed)
 	_adapter.connected.connect(self._connected)
-	_adapter.received_error.connect(self._connection_error)
+	_adapter.connection_error.connect(self._connection_error)
 	_adapter.received.connect(self._received)
 
 func _notification(what):

--- a/addons/com.heroiclabs.nakama/socket/NakamaSocketAdapter.gd
+++ b/addons/com.heroiclabs.nakama/socket/NakamaSocketAdapter.gd
@@ -17,7 +17,7 @@ signal connected()
 signal closed()
 
 # A signal emitted when the socket has an error when connecting.
-signal received_error(p_exception)
+signal connection_error(p_exception)
 
 # A signal emitted when the socket receives a message.
 signal received(p_bytes) # PackedByteArray
@@ -43,7 +43,7 @@ func connect_to_host(p_uri : String, p_timeout : int):
 	var err = _ws.connect_to_url(p_uri)
 	if err != OK:
 		logger.debug("Error connecting to host %s" % p_uri)
-		call_deferred("emit_signal", "received_error", err)
+		call_deferred("emit_signal", "connection_error", err)
 		return
 	_ws_last_state = WebSocketPeer.STATE_CLOSED
 
@@ -68,7 +68,7 @@ func _process(delta):
 	if state == WebSocketPeer.STATE_CONNECTING:
 		if _start + _timeout < Time.get_unix_time_from_system():
 			logger.debug("Timeout when connecting to socket")
-			received_error.emit(ERR_TIMEOUT)
+			connection_error.emit(ERR_TIMEOUT)
 			_ws.close()
 
 	while _ws.get_ready_state() == WebSocketPeer.STATE_OPEN and _ws.get_available_packet_count():

--- a/addons/com.heroiclabs.nakama/utils/NakamaMultiplayerBridge.gd
+++ b/addons/com.heroiclabs.nakama/utils/NakamaMultiplayerBridge.gd
@@ -157,7 +157,7 @@ func _on_nakama_socket_received_matchmaker_matched(matchmaker_matched) -> void:
 				_host_add_peer(presence)
 
 func _on_nakama_socket_closed() -> void:
-	match_state = MatchState.SOCKET_CLOSED
+	_match_state = MatchState.SOCKET_CLOSED
 	_cleanup()
 
 func get_user_presence_for_peer(peer_id: int) -> NakamaRTAPI.UserPresence:


### PR DESCRIPTION
This pull request fixes two minor issues.

1. `_match_state` is never actually updated in `NakamaMultiplayerBridge._on_nakama_socket_closed()` because the `match_state` property has a readonly setter
2. The `NakamaSocketAdapter.received_error` signal is renamed to `connection_error` to agree with the `NakamaSocket.connection_error` signal