### PR TITLE
Removed code which causes Godot 3 to report memory leaks (#57)

### DIFF
--- a/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaAPI.gd
@@ -27,7 +27,7 @@ class GroupUserListGroupUser extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> GroupUserListGroupUser:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "GroupUserListGroupUser", p_dict), GroupUserListGroupUser) as GroupUserListGroupUser
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "GroupUserListGroupUser", p_dict), GroupUserListGroupUser)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -64,7 +64,7 @@ class UserGroupListUserGroup extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> UserGroupListUserGroup:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "UserGroupListUserGroup", p_dict), UserGroupListUserGroup) as UserGroupListUserGroup
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "UserGroupListUserGroup", p_dict), UserGroupListUserGroup)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -115,7 +115,7 @@ class WriteLeaderboardRecordRequestLeaderboardRecordWrite extends NakamaAsyncRes
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> WriteLeaderboardRecordRequestLeaderboardRecordWrite:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "WriteLeaderboardRecordRequestLeaderboardRecordWrite", p_dict), WriteLeaderboardRecordRequestLeaderboardRecordWrite) as WriteLeaderboardRecordRequestLeaderboardRecordWrite
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "WriteLeaderboardRecordRequestLeaderboardRecordWrite", p_dict), WriteLeaderboardRecordRequestLeaderboardRecordWrite)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -168,7 +168,7 @@ class WriteTournamentRecordRequestTournamentRecordWrite extends NakamaAsyncResul
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> WriteTournamentRecordRequestTournamentRecordWrite:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "WriteTournamentRecordRequestTournamentRecordWrite", p_dict), WriteTournamentRecordRequestTournamentRecordWrite) as WriteTournamentRecordRequestTournamentRecordWrite
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "WriteTournamentRecordRequestTournamentRecordWrite", p_dict), WriteTournamentRecordRequestTournamentRecordWrite)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -252,7 +252,7 @@ class ApiAccount extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiAccount:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccount", p_dict), ApiAccount) as ApiAccount
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccount", p_dict), ApiAccount)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -294,7 +294,7 @@ class ApiAccountApple extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiAccountApple:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountApple", p_dict), ApiAccountApple) as ApiAccountApple
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountApple", p_dict), ApiAccountApple)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -335,7 +335,7 @@ class ApiAccountCustom extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiAccountCustom:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountCustom", p_dict), ApiAccountCustom) as ApiAccountCustom
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountCustom", p_dict), ApiAccountCustom)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -376,7 +376,7 @@ class ApiAccountDevice extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiAccountDevice:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountDevice", p_dict), ApiAccountDevice) as ApiAccountDevice
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountDevice", p_dict), ApiAccountDevice)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -424,7 +424,7 @@ class ApiAccountEmail extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiAccountEmail:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountEmail", p_dict), ApiAccountEmail) as ApiAccountEmail
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountEmail", p_dict), ApiAccountEmail)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -466,7 +466,7 @@ class ApiAccountFacebook extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiAccountFacebook:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountFacebook", p_dict), ApiAccountFacebook) as ApiAccountFacebook
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountFacebook", p_dict), ApiAccountFacebook)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -507,7 +507,7 @@ class ApiAccountFacebookInstantGame extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiAccountFacebookInstantGame:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountFacebookInstantGame", p_dict), ApiAccountFacebookInstantGame) as ApiAccountFacebookInstantGame
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountFacebookInstantGame", p_dict), ApiAccountFacebookInstantGame)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -583,7 +583,7 @@ class ApiAccountGameCenter extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiAccountGameCenter:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountGameCenter", p_dict), ApiAccountGameCenter) as ApiAccountGameCenter
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountGameCenter", p_dict), ApiAccountGameCenter)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -629,7 +629,7 @@ class ApiAccountGoogle extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiAccountGoogle:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountGoogle", p_dict), ApiAccountGoogle) as ApiAccountGoogle
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountGoogle", p_dict), ApiAccountGoogle)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -670,7 +670,7 @@ class ApiAccountSteam extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiAccountSteam:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountSteam", p_dict), ApiAccountSteam) as ApiAccountSteam
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiAccountSteam", p_dict), ApiAccountSteam)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -788,7 +788,7 @@ class ApiChannelMessage extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiChannelMessage:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiChannelMessage", p_dict), ApiChannelMessage) as ApiChannelMessage
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiChannelMessage", p_dict), ApiChannelMessage)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -850,7 +850,7 @@ class ApiChannelMessageList extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiChannelMessageList:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiChannelMessageList", p_dict), ApiChannelMessageList) as ApiChannelMessageList
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiChannelMessageList", p_dict), ApiChannelMessageList)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -917,7 +917,7 @@ class ApiCreateGroupRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiCreateGroupRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiCreateGroupRequest", p_dict), ApiCreateGroupRequest) as ApiCreateGroupRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiCreateGroupRequest", p_dict), ApiCreateGroupRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -965,7 +965,7 @@ class ApiDeleteStorageObjectId extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiDeleteStorageObjectId:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiDeleteStorageObjectId", p_dict), ApiDeleteStorageObjectId) as ApiDeleteStorageObjectId
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiDeleteStorageObjectId", p_dict), ApiDeleteStorageObjectId)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -996,7 +996,7 @@ class ApiDeleteStorageObjectsRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiDeleteStorageObjectsRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiDeleteStorageObjectsRequest", p_dict), ApiDeleteStorageObjectsRequest) as ApiDeleteStorageObjectsRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiDeleteStorageObjectsRequest", p_dict), ApiDeleteStorageObjectsRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1046,7 +1046,7 @@ class ApiEvent extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiEvent:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiEvent", p_dict), ApiEvent) as ApiEvent
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiEvent", p_dict), ApiEvent)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1096,7 +1096,7 @@ class ApiFriend extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiFriend:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiFriend", p_dict), ApiFriend) as ApiFriend
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiFriend", p_dict), ApiFriend)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1134,7 +1134,7 @@ class ApiFriendList extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiFriendList:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiFriendList", p_dict), ApiFriendList) as ApiFriendList
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiFriendList", p_dict), ApiFriendList)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1241,7 +1241,7 @@ class ApiGroup extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiGroup:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiGroup", p_dict), ApiGroup) as ApiGroup
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiGroup", p_dict), ApiGroup)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1288,7 +1288,7 @@ class ApiGroupList extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiGroupList:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiGroupList", p_dict), ApiGroupList) as ApiGroupList
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiGroupList", p_dict), ApiGroupList)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1325,7 +1325,7 @@ class ApiGroupUserList extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiGroupUserList:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiGroupUserList", p_dict), ApiGroupUserList) as ApiGroupUserList
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiGroupUserList", p_dict), ApiGroupUserList)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1432,7 +1432,7 @@ class ApiLeaderboardRecord extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiLeaderboardRecord:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiLeaderboardRecord", p_dict), ApiLeaderboardRecord) as ApiLeaderboardRecord
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiLeaderboardRecord", p_dict), ApiLeaderboardRecord)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1493,7 +1493,7 @@ class ApiLeaderboardRecordList extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiLeaderboardRecordList:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiLeaderboardRecordList", p_dict), ApiLeaderboardRecordList) as ApiLeaderboardRecordList
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiLeaderboardRecordList", p_dict), ApiLeaderboardRecordList)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1532,7 +1532,7 @@ class ApiLinkSteamRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiLinkSteamRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiLinkSteamRequest", p_dict), ApiLinkSteamRequest) as ApiLinkSteamRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiLinkSteamRequest", p_dict), ApiLinkSteamRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1569,7 +1569,7 @@ class ApiListSubscriptionsRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiListSubscriptionsRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiListSubscriptionsRequest", p_dict), ApiListSubscriptionsRequest) as ApiListSubscriptionsRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiListSubscriptionsRequest", p_dict), ApiListSubscriptionsRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1634,7 +1634,7 @@ class ApiMatch extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiMatch:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiMatch", p_dict), ApiMatch) as ApiMatch
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiMatch", p_dict), ApiMatch)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1668,7 +1668,7 @@ class ApiMatchList extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiMatchList:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiMatchList", p_dict), ApiMatchList) as ApiMatchList
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiMatchList", p_dict), ApiMatchList)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1739,7 +1739,7 @@ class ApiNotification extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiNotification:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiNotification", p_dict), ApiNotification) as ApiNotification
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiNotification", p_dict), ApiNotification)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1781,7 +1781,7 @@ class ApiNotificationList extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiNotificationList:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiNotificationList", p_dict), ApiNotificationList) as ApiNotificationList
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiNotificationList", p_dict), ApiNotificationList)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1833,7 +1833,7 @@ class ApiReadStorageObjectId extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiReadStorageObjectId:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiReadStorageObjectId", p_dict), ApiReadStorageObjectId) as ApiReadStorageObjectId
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiReadStorageObjectId", p_dict), ApiReadStorageObjectId)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1864,7 +1864,7 @@ class ApiReadStorageObjectsRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiReadStorageObjectsRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiReadStorageObjectsRequest", p_dict), ApiReadStorageObjectsRequest) as ApiReadStorageObjectsRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiReadStorageObjectsRequest", p_dict), ApiReadStorageObjectsRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1907,7 +1907,7 @@ class ApiRpc extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiRpc:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiRpc", p_dict), ApiRpc) as ApiRpc
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiRpc", p_dict), ApiRpc)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1952,7 +1952,7 @@ class ApiSession extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiSession:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiSession", p_dict), ApiSession) as ApiSession
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiSession", p_dict), ApiSession)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -1990,7 +1990,7 @@ class ApiSessionLogoutRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiSessionLogoutRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiSessionLogoutRequest", p_dict), ApiSessionLogoutRequest) as ApiSessionLogoutRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiSessionLogoutRequest", p_dict), ApiSessionLogoutRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2027,7 +2027,7 @@ class ApiSessionRefreshRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiSessionRefreshRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiSessionRefreshRequest", p_dict), ApiSessionRefreshRequest) as ApiSessionRefreshRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiSessionRefreshRequest", p_dict), ApiSessionRefreshRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2117,7 +2117,7 @@ class ApiStorageObject extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiStorageObject:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiStorageObject", p_dict), ApiStorageObject) as ApiStorageObject
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiStorageObject", p_dict), ApiStorageObject)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2175,7 +2175,7 @@ class ApiStorageObjectAck extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiStorageObjectAck:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiStorageObjectAck", p_dict), ApiStorageObjectAck) as ApiStorageObjectAck
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiStorageObjectAck", p_dict), ApiStorageObjectAck)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2207,7 +2207,7 @@ class ApiStorageObjectAcks extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiStorageObjectAcks:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiStorageObjectAcks", p_dict), ApiStorageObjectAcks) as ApiStorageObjectAcks
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiStorageObjectAcks", p_dict), ApiStorageObjectAcks)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2243,7 +2243,7 @@ class ApiStorageObjectList extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiStorageObjectList:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiStorageObjectList", p_dict), ApiStorageObjectList) as ApiStorageObjectList
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiStorageObjectList", p_dict), ApiStorageObjectList)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2273,7 +2273,7 @@ class ApiStorageObjects extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiStorageObjects:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiStorageObjects", p_dict), ApiStorageObjects) as ApiStorageObjects
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiStorageObjects", p_dict), ApiStorageObjects)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2328,7 +2328,7 @@ class ApiSubscriptionList extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiSubscriptionList:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiSubscriptionList", p_dict), ApiSubscriptionList) as ApiSubscriptionList
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiSubscriptionList", p_dict), ApiSubscriptionList)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2492,7 +2492,7 @@ class ApiTournament extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiTournament:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiTournament", p_dict), ApiTournament) as ApiTournament
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiTournament", p_dict), ApiTournament)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2547,7 +2547,7 @@ class ApiTournamentList extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiTournamentList:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiTournamentList", p_dict), ApiTournamentList) as ApiTournamentList
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiTournamentList", p_dict), ApiTournamentList)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2598,7 +2598,7 @@ class ApiTournamentRecordList extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiTournamentRecordList:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiTournamentRecordList", p_dict), ApiTournamentRecordList) as ApiTournamentRecordList
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiTournamentRecordList", p_dict), ApiTournamentRecordList)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2665,7 +2665,7 @@ class ApiUpdateAccountRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiUpdateAccountRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiUpdateAccountRequest", p_dict), ApiUpdateAccountRequest) as ApiUpdateAccountRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiUpdateAccountRequest", p_dict), ApiUpdateAccountRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2734,7 +2734,7 @@ class ApiUpdateGroupRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiUpdateGroupRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiUpdateGroupRequest", p_dict), ApiUpdateGroupRequest) as ApiUpdateGroupRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiUpdateGroupRequest", p_dict), ApiUpdateGroupRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2887,7 +2887,7 @@ class ApiUser extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiUser:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiUser", p_dict), ApiUser) as ApiUser
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiUser", p_dict), ApiUser)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2940,7 +2940,7 @@ class ApiUserGroupList extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiUserGroupList:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiUserGroupList", p_dict), ApiUserGroupList) as ApiUserGroupList
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiUserGroupList", p_dict), ApiUserGroupList)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -2970,7 +2970,7 @@ class ApiUsers extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiUsers:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiUsers", p_dict), ApiUsers) as ApiUsers
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiUsers", p_dict), ApiUsers)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -3006,7 +3006,7 @@ class ApiValidatePurchaseAppleRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiValidatePurchaseAppleRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidatePurchaseAppleRequest", p_dict), ApiValidatePurchaseAppleRequest) as ApiValidatePurchaseAppleRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidatePurchaseAppleRequest", p_dict), ApiValidatePurchaseAppleRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -3043,7 +3043,7 @@ class ApiValidatePurchaseGoogleRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiValidatePurchaseGoogleRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidatePurchaseGoogleRequest", p_dict), ApiValidatePurchaseGoogleRequest) as ApiValidatePurchaseGoogleRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidatePurchaseGoogleRequest", p_dict), ApiValidatePurchaseGoogleRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -3087,7 +3087,7 @@ class ApiValidatePurchaseHuaweiRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiValidatePurchaseHuaweiRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidatePurchaseHuaweiRequest", p_dict), ApiValidatePurchaseHuaweiRequest) as ApiValidatePurchaseHuaweiRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidatePurchaseHuaweiRequest", p_dict), ApiValidatePurchaseHuaweiRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -3118,7 +3118,7 @@ class ApiValidatePurchaseResponse extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiValidatePurchaseResponse:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidatePurchaseResponse", p_dict), ApiValidatePurchaseResponse) as ApiValidatePurchaseResponse
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidatePurchaseResponse", p_dict), ApiValidatePurchaseResponse)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -3154,7 +3154,7 @@ class ApiValidateSubscriptionAppleRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiValidateSubscriptionAppleRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidateSubscriptionAppleRequest", p_dict), ApiValidateSubscriptionAppleRequest) as ApiValidateSubscriptionAppleRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidateSubscriptionAppleRequest", p_dict), ApiValidateSubscriptionAppleRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -3191,7 +3191,7 @@ class ApiValidateSubscriptionGoogleRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiValidateSubscriptionGoogleRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidateSubscriptionGoogleRequest", p_dict), ApiValidateSubscriptionGoogleRequest) as ApiValidateSubscriptionGoogleRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidateSubscriptionGoogleRequest", p_dict), ApiValidateSubscriptionGoogleRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -3221,7 +3221,7 @@ class ApiValidateSubscriptionResponse extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiValidateSubscriptionResponse:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidateSubscriptionResponse", p_dict), ApiValidateSubscriptionResponse) as ApiValidateSubscriptionResponse
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidateSubscriptionResponse", p_dict), ApiValidateSubscriptionResponse)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -3320,7 +3320,7 @@ class ApiValidatedPurchase extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiValidatedPurchase:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidatedPurchase", p_dict), ApiValidatedPurchase) as ApiValidatedPurchase
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidatedPurchase", p_dict), ApiValidatedPurchase)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -3443,7 +3443,7 @@ class ApiValidatedSubscription extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiValidatedSubscription:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidatedSubscription", p_dict), ApiValidatedSubscription) as ApiValidatedSubscription
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiValidatedSubscription", p_dict), ApiValidatedSubscription)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -3519,7 +3519,7 @@ class ApiWriteStorageObject extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiWriteStorageObject:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiWriteStorageObject", p_dict), ApiWriteStorageObject) as ApiWriteStorageObject
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiWriteStorageObject", p_dict), ApiWriteStorageObject)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -3553,7 +3553,7 @@ class ApiWriteStorageObjectsRequest extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ApiWriteStorageObjectsRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiWriteStorageObjectsRequest", p_dict), ApiWriteStorageObjectsRequest) as ApiWriteStorageObjectsRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ApiWriteStorageObjectsRequest", p_dict), ApiWriteStorageObjectsRequest)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -3589,7 +3589,7 @@ class ProtobufAny extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ProtobufAny:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ProtobufAny", p_dict), ProtobufAny) as ProtobufAny
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ProtobufAny", p_dict), ProtobufAny)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)
@@ -3633,7 +3633,7 @@ class RpcStatus extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> RpcStatus:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "RpcStatus", p_dict), RpcStatus) as RpcStatus
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "RpcStatus", p_dict), RpcStatus)
 
 	func serialize() -> Dictionary:
 		return NakamaSerializer.serialize(self)

--- a/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
+++ b/addons/com.heroiclabs.nakama/api/NakamaRTAPI.gd
@@ -46,7 +46,7 @@ class Channel extends NakamaAsyncResult:
 		]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> Channel:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "Channel", p_dict), Channel) as Channel
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "Channel", p_dict), Channel)
 
 	static func get_result_key() -> String:
 		return "channel"
@@ -111,7 +111,7 @@ class ChannelMessageAck extends NakamaAsyncResult:
 		]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ChannelMessageAck:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ChannelMessageAck", p_dict), ChannelMessageAck) as ChannelMessageAck
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ChannelMessageAck", p_dict), ChannelMessageAck)
 
 	static func get_result_key() -> String:
 		return "channel_message_ack"
@@ -161,7 +161,7 @@ class ChannelPresenceEvent extends NakamaAsyncResult:
 		]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> ChannelPresenceEvent:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ChannelPresenceEvent", p_dict), ChannelPresenceEvent) as ChannelPresenceEvent
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "ChannelPresenceEvent", p_dict), ChannelPresenceEvent)
 
 	static func get_result_key() -> String:
 		return "channel_presence_event"
@@ -213,7 +213,7 @@ class Error extends NakamaAsyncResult:
 		return "Error<code=%s, messages=%s, context=%s>" % [code, message, context]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> Error:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "Error", p_dict), Error) as Error
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "Error", p_dict), Error)
 
 	static func get_result_key() -> String:
 		return "error"
@@ -252,8 +252,8 @@ class Match extends NakamaAsyncResult:
 	func _init(p_ex = null).(p_ex):
 		pass
 
-	static func create(p_ns : GDScript, p_dict : Dictionary):
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "Match", p_dict), Match) as Match
+	static func create(p_ns : GDScript, p_dict : Dictionary) -> Match:
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "Match", p_dict), Match)
 
 	func _to_string():
 		if is_exception(): return get_exception()._to_string()
@@ -299,7 +299,7 @@ class MatchData extends NakamaAsyncResult:
 		return "MatchData<match_id=%s, op_code=%s, presence=%s, data=%s>" % [match_id, op_code, presence, data]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> MatchData:
-		var out := _safe_ret(NakamaSerializer.deserialize(p_ns, "MatchData", p_dict), MatchData) as MatchData
+		var out = _safe_ret(NakamaSerializer.deserialize(p_ns, "MatchData", p_dict), MatchData)
 		# Store the base64 data, ready to be decoded when the developer requests it.
 		if out.data:
 			out.base64_data = out.data
@@ -345,7 +345,7 @@ class MatchPresenceEvent extends NakamaAsyncResult:
 		return "MatchPresenceEvent<match_id=%s, joins=%s, leaves=%s>" % [match_id, joins, leaves]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> MatchPresenceEvent:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "MatchPresenceEvent", p_dict), MatchPresenceEvent) as MatchPresenceEvent
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "MatchPresenceEvent", p_dict), MatchPresenceEvent)
 
 	static func get_result_key() -> String:
 		return "match_presence_event"
@@ -388,7 +388,7 @@ class MatchmakerMatched extends NakamaAsyncResult:
 		]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> MatchmakerMatched:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "MatchmakerMatched", p_dict), MatchmakerMatched) as MatchmakerMatched
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "MatchmakerMatched", p_dict), MatchmakerMatched)
 
 	static func get_result_key() -> String:
 		return "matchmaker_matched"
@@ -408,7 +408,7 @@ class MatchmakerTicket extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> MatchmakerTicket:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "MatchmakerTicket", p_dict), MatchmakerTicket) as MatchmakerTicket
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "MatchmakerTicket", p_dict), MatchmakerTicket)
 
 	func _to_string():
 		if is_exception(): return get_exception()._to_string()
@@ -449,7 +449,7 @@ class MatchmakerUser extends NakamaAsyncResult:
 			presence, numeric_properties, string_properties]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> MatchmakerUser:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "MatchmakerUser", p_dict), MatchmakerUser) as MatchmakerUser
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "MatchmakerUser", p_dict), MatchmakerUser)
 
 	static func get_result_key() -> String:
 		return "matchmaker_user"
@@ -469,7 +469,7 @@ class Status extends NakamaAsyncResult:
 		pass
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> Status:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "Status", p_dict), Status) as Status
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "Status", p_dict), Status)
 
 	func _to_string():
 		if is_exception(): return get_exception()._to_string()
@@ -502,7 +502,7 @@ class StatusPresenceEvent extends NakamaAsyncResult:
 		return "StatusPresenceEvent<joins=%s, leaves=%s>" % [joins, leaves]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> StatusPresenceEvent:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "StatusPresenceEvent", p_dict), StatusPresenceEvent) as StatusPresenceEvent
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "StatusPresenceEvent", p_dict), StatusPresenceEvent)
 
 	static func get_result_key() -> String:
 		return "status_presence_event"
@@ -538,7 +538,7 @@ class Stream extends NakamaAsyncResult:
 		return "Stream<mode=%s, subject=%s, subcontext=%s, label=%s>" % [mode, subject, subcontext, label]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> Stream:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "Stream", p_dict), Stream) as Stream
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "Stream", p_dict), Stream)
 
 	static func get_result_key() -> String:
 		return "stream"
@@ -568,7 +568,7 @@ class StreamPresenceEvent extends NakamaAsyncResult:
 		return "StreamPresenceEvent<stream=%s, joins=%s, leaves=%s>" % [stream, joins, leaves]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> StreamPresenceEvent:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "StreamPresenceEvent", p_dict), StreamPresenceEvent) as StreamPresenceEvent
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "StreamPresenceEvent", p_dict), StreamPresenceEvent)
 
 	static func get_result_key() -> String:
 		return "stream_presence_event"
@@ -601,7 +601,7 @@ class StreamData extends NakamaAsyncResult:
 		return "StreamData<sender=%s, state=%s, stream=%s>" % [sender, state, stream]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> StreamData:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "StreamData", p_dict), StreamData) as StreamData
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "StreamData", p_dict), StreamData)
 
 	static func get_result_key() -> String:
 		return "stream_data"
@@ -647,7 +647,7 @@ class UserPresence extends NakamaAsyncResult:
 			persistence, session_id, status, username, user_id]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> UserPresence:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "UserPresence", p_dict), UserPresence) as UserPresence
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "UserPresence", p_dict), UserPresence)
 
 	static func get_result_key() -> String:
 		return "user_presence"
@@ -694,7 +694,7 @@ class Party extends NakamaAsyncResult:
 			party_id, open, max_size, self_presence, leader, presences]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> Party:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "Party", p_dict), Party) as Party
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "Party", p_dict), Party)
 
 	static func get_result_key() -> String:
 		return "party"
@@ -725,7 +725,7 @@ class PartyPresenceEvent extends NakamaAsyncResult:
 		return "PartyPresenceEvent<party_id=%s, joins=%s, leaves=%s>" % [party_id, joins, leaves]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> PartyPresenceEvent:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "PartyPresenceEvent", p_dict), PartyPresenceEvent) as PartyPresenceEvent
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "PartyPresenceEvent", p_dict), PartyPresenceEvent)
 
 	static func get_result_key() -> String:
 		return "party_presence_event"
@@ -753,7 +753,7 @@ class PartyLeader extends NakamaAsyncResult:
 		return "PartyLeader<party_id=%s, presence=%s>" % [party_id, presence]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> PartyLeader:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "PartyLeader", p_dict), PartyLeader) as PartyLeader
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "PartyLeader", p_dict), PartyLeader)
 
 	static func get_result_key() -> String:
 		return "party_leader"
@@ -781,7 +781,7 @@ class PartyJoinRequest extends NakamaAsyncResult:
 		return "PartyJoinRequest<party_id=%s, presences=%s>" % [party_id, presences]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> PartyJoinRequest:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "PartyJoinRequest", p_dict), PartyJoinRequest) as PartyJoinRequest
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "PartyJoinRequest", p_dict), PartyJoinRequest)
 
 	static func get_result_key() -> String:
 		return "party_join_request"
@@ -809,7 +809,7 @@ class PartyMatchmakerTicket extends NakamaAsyncResult:
 		return "PartyMatchmakerTicket<party_id=%s, ticket=%s>" % [party_id, ticket]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> PartyMatchmakerTicket:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "PartyMatchmakerTicket", p_dict), PartyMatchmakerTicket) as PartyMatchmakerTicket
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "PartyMatchmakerTicket", p_dict), PartyMatchmakerTicket)
 
 	static func get_result_key() -> String:
 		return "party_matchmaker_ticket"
@@ -847,7 +847,7 @@ class PartyData extends NakamaAsyncResult:
 		return "PartyData<party_id=%s, presence=%s, op_code=%d, data%s>" % [party_id, presence, op_code, data]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> PartyData:
-		var out := _safe_ret(NakamaSerializer.deserialize(p_ns, "PartyData", p_dict), PartyData) as PartyData
+		var out = _safe_ret(NakamaSerializer.deserialize(p_ns, "PartyData", p_dict), PartyData)
 		# Store the base64 data, ready to be decoded when the developer requests it.
 		if out.data:
 			out.base64_data = out.data
@@ -889,7 +889,7 @@ class PartyClose extends NakamaAsyncResult:
 		return "PartyClose<party_id=%s>" % [party_id]
 
 	static func create(p_ns : GDScript, p_dict : Dictionary) -> PartyClose:
-		return _safe_ret(NakamaSerializer.deserialize(p_ns, "PartyClose", p_dict), PartyClose) as PartyClose
+		return _safe_ret(NakamaSerializer.deserialize(p_ns, "PartyClose", p_dict), PartyClose)
 
 	static func get_result_key() -> String:
 		return "party_close"


### PR DESCRIPTION
Godot 3 does not support classes referencing their own class type *inside* their own functions. Using the `is` keyword in combination will throw a parser error. But using the `as` keyword similarly does not. Its apparent downstream affect is at least reports of memory leaks.

I have tagged #57 in an associated Godot repo issue and appealed for a Godot maintainer to target Godot 3.6 as it was targeted to Godot 3.5, proposing a solution to guard against this usage of `as`, as it's unlikely to receive the circular dependency enhancement that Godot 4 received--this nakama-godot issue *does not* reproduce with Godot 4.