### PR TITLE
Config: exclude some files in the Asset Library download

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Exclude irrelevant files when downloading from the Asset Library.
+/.github                                 export-ignore
+/.gitignore                              export-ignore
+/.gitattributes                          export-ignore
+/codegen                                 export-ignore
+/test_suite                              export-ignore
+/CHANGELOG.md                            export-ignore
+/LICENSE                                 export-ignore
+/README.md                               export-ignore
+/icon.svg                                export-ignore
+/project.godot                           export-ignore


### PR DESCRIPTION
Currently, adding this addon via the Asset Library inside Godot requires resolving file conflicts.

This MR fixes that.

---

Important Note
--------------

The test suite has been excluded ; it could well be included, as long as it resided under `addons/` and not at the root.