### PR TITLE
[feat]: Nakama now has a `plugin.gd` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,31 @@ You'll need to setup the server and database before you can connect with the cli
 
 2. Download the client from the [releases page](https://github.com/heroiclabs/nakama-godot/releases) and import it into your project. You can also [download it from the asset repository](#asset-repository).
 
-3. Add the `Nakama.gd` singleton (in `addons/com.heroiclabs.nakama/`) as an [autoload in Godot](https://docs.godotengine.org/en/stable/getting_started/step_by_step/singletons_autoload.html).
+3. Once downloaded, extract the contents of the zip into the ```addons``` folder. Your project directory should look something like this:
 
-4. Use the connection credentials to build a client object using the singleton.
+```
+Your Project
+	addons
+		com.heroiclabs.nakama
+			...plugin files
+		...other plugins
+	...other files
+```
 
-    ```gdscript
-    extends Node
+4. Activate the plugin in the `Plugins` tab, in ```Project Settings > Plugins```
 
-    func _ready():
-    	var scheme = "http"
-    	var host = "127.0.0.1"
-    	var port = 7350
-    	var server_key = "defaultkey"
-    	var client := Nakama.create_client(server_key, host, port, scheme)
-    ```
+5. Use the connection credentials to build a client object using the singleton.
+
+	```gdscript
+	extends Node
+
+	func _ready():
+		var scheme = "http"
+		var host = "127.0.0.1"
+		var port = 7350
+		var server_key = "defaultkey"
+		var client := Nakama.create_client(server_key, host, port, scheme)
+	```
 
 ## Usage
 

--- a/addons/com.heroiclabs.nakama/com.heroiclabs.nakama.gd
+++ b/addons/com.heroiclabs.nakama/com.heroiclabs.nakama.gd
@@ -1,0 +1,17 @@
+@tool
+extends EditorPlugin
+
+const NAKAMA_AUTOLOAD_NAME := "Nakama"
+const NAKAMA_AUTOLOAD_PATH := "res://addons/com.heroiclabs.nakama/Nakama.gd"
+
+func _enter_tree() -> void:
+	_initialize_autoloads()
+	
+func _exit_tree() -> void:
+	_remove_autoloads()
+
+func _initialize_autoloads() -> void:
+	add_autoload_singleton(NAKAMA_AUTOLOAD_NAME, NAKAMA_AUTOLOAD_PATH)
+	
+func _remove_autoloads() -> void:
+	remove_autoload_singleton(NAKAMA_AUTOLOAD_NAME)

--- a/addons/com.heroiclabs.nakama/com.heroiclabs.nakama.gd.uid
+++ b/addons/com.heroiclabs.nakama/com.heroiclabs.nakama.gd.uid
@@ -1,0 +1,1 @@
+uid://b0mnoxm5eqce2

--- a/project.godot
+++ b/project.godot
@@ -13,8 +13,3 @@ config_version=5
 config/name="nakama-godot"
 config/features=PackedStringArray("4.4")
 config/icon="res://icon.svg"
-
-[autoload]
-
-Nakama="*res://addons/com.heroiclabs.nakama/Nakama.gd"
-Satori="*res://addons/com.heroiclabs.nakama/Satori.gd"


### PR DESCRIPTION
# Summary

This PR adds a ```plugin.gd``` file to properly register Nakama.gd as an autoload through Godot’s plugin system. This ensures the Nakama client is always available without requiring manual setup.

# Changes

- Added plugin.gd to handle autoload registration of Nakama.gd.
- Updated README to document enabling the plugin via Project Settings → Plugins.

# Why

Previously, the project lacked a plugin.gd, requiring manual configuration to load Nakama.gd. With this change, enabling the plugin in Project Settings automatically sets up the autoload, simplifying the integration process.
