### PR TITLE
Add Nakama.get_device_id() for stable and secure device authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test_suite/.import/*
 *.cache
 .vscode
 .godot
+.DS_Store

--- a/addons/com.heroiclabs.nakama/Nakama.gd
+++ b/addons/com.heroiclabs.nakama/Nakama.gd
@@ -19,7 +19,11 @@ const DEFAULT_SOCKET_SCHEME : String = "ws"
 ## The default log level for the Nakama logger.
 const DEFAULT_LOG_LEVEL = NakamaLogger.LOG_LEVEL.DEBUG
 
+## The path where the generated device identifier is persisted.
+const DEVICE_ID_PATH : String = "user://nakama_device_id"
+
 var _http_adapter = null
+var _device_id : String = ""
 var logger = NakamaLogger.new()
 
 func _ready() -> void:
@@ -59,3 +63,36 @@ func create_socket_from(p_client : NakamaClient) -> NakamaSocket:
 	if p_client.scheme == "https":
 		scheme = "wss"
 	return NakamaSocket.new(create_socket_adapter(), p_client.host, p_client.port, scheme, true)
+
+func get_device_id() -> String:
+	if _device_id != "":
+		return _device_id
+
+	if FileAccess.file_exists(DEVICE_ID_PATH):
+		var read_file := FileAccess.open(DEVICE_ID_PATH, FileAccess.READ)
+		if read_file != null:
+			var stored := read_file.get_as_text().strip_edges()
+			read_file.close()
+			if stored != "":
+				_device_id = stored
+				return _device_id
+		else:
+			logger.error("Unable to read the device id from '%s', error code: %d" % [DEVICE_ID_PATH, FileAccess.get_open_error()])
+
+	var hex := Crypto.new().generate_random_bytes(16).hex_encode()
+	_device_id = "%s-%s-%s-%s-%s" % [
+		hex.substr(0, 8),
+		hex.substr(8, 4),
+		hex.substr(12, 4),
+		hex.substr(16, 4),
+		hex.substr(20, 12),
+	]
+
+	var write_file := FileAccess.open(DEVICE_ID_PATH, FileAccess.WRITE)
+	if write_file != null:
+		write_file.store_string(_device_id)
+		write_file.close()
+	else:
+		logger.error("Unable to persist the device id to '%s', error code: %d. A new device id will be generated the next time the game starts, creating a new account." % [DEVICE_ID_PATH, FileAccess.get_open_error()])
+
+	return _device_id


### PR DESCRIPTION
Adds `Nakama.get_device_id()`, returning a stable and secure per-device identifier suitable for `NakamaClient.authenticate_device_async()`.

The [current implementation suggestion](https://heroiclabs.com/docs/nakama/concepts/authentication/#device), using `OS.get_unique_id()`, is not ideal as the device_id can be accessed by other Apps on the system, which could effectively allow them to authenticate against the Nakama APIs.