### PR TITLE
Cap max timeout

### DIFF
--- a/addons/com.heroiclabs.nakama/Satori/SatoriHttpAdapter.gd
+++ b/addons/com.heroiclabs.nakama/Satori/SatoriHttpAdapter.gd
@@ -17,8 +17,8 @@ var auto_retry : bool = true
 var auto_retry_count : int = 3
 var auto_retry_backoff_base : int = 10
 
-## Maximum total duration in milliseconds across all retries.
-var max_total_timeout_ms : int = 1500
+## Maximum total duration in milliseconds across all retries. Set to 0 to disable.
+var max_total_timeout_ms : int = 10000
 
 ## Whether or not to use threads when making HTTP requests.
 var use_threads : bool = true
@@ -44,7 +44,7 @@ class AsyncRequest:
 	var timer : SceneTreeTimer = null
 	var cur_try : int = 1
 	var rng = RandomNumberGenerator.new()
-	var max_total_timeout_ms : int = 1500
+	var max_total_timeout_ms : int = 10000
 
 	func _init(p_id : int, p_request : HTTPRequest, p_uri : String,
 			p_method : int, p_headers : PackedStringArray, p_body : PackedByteArray,
@@ -204,8 +204,10 @@ static func _send_async(p_id : int, p_pending : Dictionary):
 
 	var req : AsyncRequest = p_pending[p_id]
 
-	var global_timer = req.request.get_tree().create_timer(req.max_total_timeout_ms / 1000.0)
-	global_timer.timeout.connect(req.cancel)
+	var global_timer : SceneTreeTimer = null
+	if req.max_total_timeout_ms > 0:
+		global_timer = req.request.get_tree().create_timer(req.max_total_timeout_ms / 1000.0)
+		global_timer.timeout.connect(req.cancel)
 
 	await req.make_request()
 
@@ -217,7 +219,7 @@ static func _send_async(p_id : int, p_pending : Dictionary):
 			break
 		await req.retry()
 
-	if global_timer.timeout.is_connected(req.cancel):
+	if global_timer != null and global_timer.timeout.is_connected(req.cancel):
 		global_timer.timeout.disconnect(req.cancel)
 
 	_clear_request(req, p_pending, p_id)

--- a/addons/com.heroiclabs.nakama/Satori/SatoriHttpAdapter.gd
+++ b/addons/com.heroiclabs.nakama/Satori/SatoriHttpAdapter.gd
@@ -17,6 +17,9 @@ var auto_retry : bool = true
 var auto_retry_count : int = 3
 var auto_retry_backoff_base : int = 10
 
+## Maximum total duration in milliseconds across all retries.
+var max_total_timeout_ms : int = 1500
+
 ## Whether or not to use threads when making HTTP requests.
 var use_threads : bool = true
 
@@ -41,10 +44,12 @@ class AsyncRequest:
 	var timer : SceneTreeTimer = null
 	var cur_try : int = 1
 	var rng = RandomNumberGenerator.new()
+	var max_total_timeout_ms : int = 1500
 
 	func _init(p_id : int, p_request : HTTPRequest, p_uri : String,
 			p_method : int, p_headers : PackedStringArray, p_body : PackedByteArray,
-			p_retry_count : int, p_backoff_time : int, p_logger : SatoriLogger):
+			p_retry_count : int, p_backoff_time : int, p_logger : SatoriLogger,
+			p_max_total_timeout_ms : int):
 		rng.seed = Time.get_ticks_usec()
 		id = p_id
 		request = p_request
@@ -55,9 +60,10 @@ class AsyncRequest:
 		retry_count = p_retry_count
 		backoff_time = p_backoff_time
 		logger = p_logger
+		max_total_timeout_ms = p_max_total_timeout_ms
 
 	func should_retry():
-		return cur_try < retry_count and not cancelled
+		return not cancelled and cur_try < retry_count
 
 	func retry():
 		var time = pow(backoff_time, cur_try) * rng.randf_range(0.5, 1)
@@ -171,7 +177,7 @@ func send_async(p_method : String, p_uri : String, p_headers : Dictionary, p_bod
 	id += 1
 	var retry = auto_retry_count if auto_retry else 0
 	var backoff = auto_retry_backoff_base
-	_pending[id] = AsyncRequest.new(id, req, p_uri, method, headers, p_body, retry, backoff, logger)
+	_pending[id] = AsyncRequest.new(id, req, p_uri, method, headers, p_body, retry, backoff, logger, max_total_timeout_ms)
 
 	logger.debug("Sending request [ID: %d, Method: %s, Uri: %s, Headers: %s, Body: %s, Timeout: %d, Retries: %d, Backoff base: %d ms]" % [
 		id, p_method, p_uri, p_headers, p_body.get_string_from_utf8(), timeout, retry, backoff
@@ -197,6 +203,10 @@ static func _clear_request(p_request : AsyncRequest, p_pending : Dictionary, p_i
 static func _send_async(p_id : int, p_pending : Dictionary):
 
 	var req : AsyncRequest = p_pending[p_id]
+
+	var global_timer = req.request.get_tree().create_timer(req.max_total_timeout_ms / 1000.0)
+	global_timer.timeout.connect(req.cancel)
+
 	await req.make_request()
 
 	while req.result != HTTPRequest.RESULT_SUCCESS:
@@ -206,6 +216,9 @@ static func _send_async(p_id : int, p_pending : Dictionary):
 		if not req.should_retry():
 			break
 		await req.retry()
+
+	if global_timer.timeout.is_connected(req.cancel):
+		global_timer.timeout.disconnect(req.cancel)
 
 	_clear_request(req, p_pending, p_id)
 	return req.parse_result()

--- a/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
@@ -17,6 +17,9 @@ var auto_retry : bool = true
 var auto_retry_count : int = 3
 var auto_retry_backoff_base : int = 10
 
+## Maximum total duration in milliseconds across all retries.
+var max_total_timeout_ms : int = 1500
+
 ## Whether or not to use threads when making HTTP requests.
 var use_threads : bool = true
 
@@ -41,10 +44,12 @@ class AsyncRequest:
 	var timer : SceneTreeTimer = null
 	var cur_try : int = 1
 	var rng = RandomNumberGenerator.new()
+	var max_total_timeout_ms : int = 1500
 
 	func _init(p_id : int, p_request : HTTPRequest, p_uri : String,
 			p_method : int, p_headers : PackedStringArray, p_body : PackedByteArray,
-			p_retry_count : int, p_backoff_time : int, p_logger : NakamaLogger):
+			p_retry_count : int, p_backoff_time : int, p_logger : NakamaLogger,
+			p_max_total_timeout_ms : int):
 		rng.seed = Time.get_ticks_usec()
 		id = p_id
 		request = p_request
@@ -55,9 +60,10 @@ class AsyncRequest:
 		retry_count = p_retry_count
 		backoff_time = p_backoff_time
 		logger = p_logger
+		max_total_timeout_ms = p_max_total_timeout_ms
 
 	func should_retry():
-		return cur_try < retry_count and not cancelled
+		return not cancelled and cur_try < retry_count
 
 	func retry():
 		var time = pow(backoff_time, cur_try) * rng.randf_range(0.5, 1)
@@ -171,7 +177,7 @@ func send_async(p_method : String, p_uri : String, p_headers : Dictionary, p_bod
 	id += 1
 	var retry = auto_retry_count if auto_retry else 0
 	var backoff = auto_retry_backoff_base
-	_pending[id] = AsyncRequest.new(id, req, p_uri, method, headers, p_body, retry, backoff, logger)
+	_pending[id] = AsyncRequest.new(id, req, p_uri, method, headers, p_body, retry, backoff, logger, max_total_timeout_ms)
 
 	logger.debug("Sending request [ID: %d, Method: %s, Uri: %s, Headers: %s, Body: %s, Timeout: %d, Retries: %d, Backoff base: %d ms]" % [
 		id, p_method, p_uri, p_headers, p_body.get_string_from_utf8(), timeout, retry, backoff
@@ -197,6 +203,10 @@ static func _clear_request(p_request : AsyncRequest, p_pending : Dictionary, p_i
 static func _send_async(p_id : int, p_pending : Dictionary):
 
 	var req : AsyncRequest = p_pending[p_id]
+
+	var global_timer = req.request.get_tree().create_timer(req.max_total_timeout_ms / 1000.0)
+	global_timer.timeout.connect(req.cancel)
+
 	await req.make_request()
 
 	while req.result != HTTPRequest.RESULT_SUCCESS:
@@ -206,6 +216,9 @@ static func _send_async(p_id : int, p_pending : Dictionary):
 		if not req.should_retry():
 			break
 		await req.retry()
+
+	if global_timer.timeout.is_connected(req.cancel):
+		global_timer.timeout.disconnect(req.cancel)
 
 	_clear_request(req, p_pending, p_id)
 	return req.parse_result()

--- a/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
+++ b/addons/com.heroiclabs.nakama/client/NakamaHTTPAdapter.gd
@@ -17,8 +17,8 @@ var auto_retry : bool = true
 var auto_retry_count : int = 3
 var auto_retry_backoff_base : int = 10
 
-## Maximum total duration in milliseconds across all retries.
-var max_total_timeout_ms : int = 1500
+## Maximum total duration in milliseconds across all retries. Set to 0 to disable.
+var max_total_timeout_ms : int = 10000
 
 ## Whether or not to use threads when making HTTP requests.
 var use_threads : bool = true
@@ -44,7 +44,7 @@ class AsyncRequest:
 	var timer : SceneTreeTimer = null
 	var cur_try : int = 1
 	var rng = RandomNumberGenerator.new()
-	var max_total_timeout_ms : int = 1500
+	var max_total_timeout_ms : int = 10000
 
 	func _init(p_id : int, p_request : HTTPRequest, p_uri : String,
 			p_method : int, p_headers : PackedStringArray, p_body : PackedByteArray,
@@ -204,8 +204,10 @@ static func _send_async(p_id : int, p_pending : Dictionary):
 
 	var req : AsyncRequest = p_pending[p_id]
 
-	var global_timer = req.request.get_tree().create_timer(req.max_total_timeout_ms / 1000.0)
-	global_timer.timeout.connect(req.cancel)
+	var global_timer : SceneTreeTimer = null
+	if req.max_total_timeout_ms > 0:
+		global_timer = req.request.get_tree().create_timer(req.max_total_timeout_ms / 1000.0)
+		global_timer.timeout.connect(req.cancel)
 
 	await req.make_request()
 
@@ -217,7 +219,7 @@ static func _send_async(p_id : int, p_pending : Dictionary):
 			break
 		await req.retry()
 
-	if global_timer.timeout.is_connected(req.cancel):
+	if global_timer != null and global_timer.timeout.is_connected(req.cancel):
 		global_timer.timeout.disconnect(req.cancel)
 
 	_clear_request(req, p_pending, p_id)

--- a/test_suite/tests/retry_timeout_test.gd
+++ b/test_suite/tests/retry_timeout_test.gd
@@ -1,0 +1,25 @@
+extends "res://base_test.gd"
+
+func setup():
+	var adapter = NakamaHTTPAdapter.new()
+	adapter.timeout = 1
+	adapter.auto_retry = true
+	adapter.auto_retry_count = 100
+	adapter.max_total_timeout_ms = 300
+	add_child(adapter)
+
+	# Send a request to a bad port, keep failing and keep retrying. 
+	# Should respect the total timeout.
+	var start_ms = Time.get_ticks_msec()
+	var result = await adapter.send_async("GET", "http://localhost:9999/", {}, PackedByteArray())
+	var elapsed_ms = Time.get_ticks_msec() - start_ms
+
+	if assert_cond(result is NakamaException):
+		return
+	if assert_cond(elapsed_ms <= 300):
+		return
+
+	done()
+
+func _process(_delta):
+	assert_time(5)

--- a/test_suite/tests/socket_multi_test.gd
+++ b/test_suite/tests/socket_multi_test.gd
@@ -2,7 +2,7 @@ extends "res://base_test.gd"
 
 var content = {"My": "message"}
 var match_string_props = {"region": "europe"}
-var match_numeric_props = {"rank": 8}
+var match_numeric_props = {"rank": 8.0}
 var got_msg = false
 var got_match = false
 var socket1 = null


### PR DESCRIPTION
Introduce an extra parameter to cap the total time we spend in a request, including across all retries.